### PR TITLE
feat(cli): enhance doctor command with modular checks and automated fixes

### DIFF
--- a/docs/NEW_FEATURES.md
+++ b/docs/NEW_FEATURES.md
@@ -81,7 +81,18 @@ A dedicated interactive tool to handle the `.conflict-<tool>` files generated du
 
 ---
 
-## 5. Technical Considerations for Go Implementation
+## 5. `axon update` (Self-Auto-Update)
+Enables the CLI to maintain itself without manual intervention from the user.
+
+### Logic
+- **Discovery**: Use the GitHub API to fetch metadata from the `latest` release of `kamusis/axon-cli`.
+- **Validation**: Compare the local version string against the remote tag.
+- **Payload Selection**: Detect the host OS and CPU architecture to select the matching binary asset (e.g., `axon-darwin-arm64.tar.gz`).
+- **Execution**: Download to a temporary location, verify the checksum if available, and replace the current executable path.
+
+---
+
+## 6. Technical Considerations for Go Implementation
 - **YAML Handling**: Use `gopkg.in/yaml.v3` for robust frontmatter extraction.
 - **Glob Matching**: Use `path/filepath.Match` or a specialized globbing library for the `excludes` logic.
 - **Local DB**: If implementing semantic search, look for Go-native embedded DBs to maintain the "Single Binary" requirement.

--- a/docs/doctor-enhancement-design.md
+++ b/docs/doctor-enhancement-design.md
@@ -1,0 +1,70 @@
+# Enhanced Axon Doctor Design
+
+## 1. Overview
+
+This design document details how the current `axon doctor` command will be enhanced into a comprehensive diagnostic and self-healing suite, according to [Issue #1](https://github.com/kamusis/axon-cli/issues/1). The aim is to surface potential configuration issues proactively and provide seamless remediation logic.
+
+## 2. Current Status Analysis
+
+Based on `src/cmd/doctor.go`, here is our current implementation breakdown regarding Issue #1 items:
+
+### 2.1 Already Implemented
+
+- **Windows Symlink Permissions**: `checkWindowsSymlinkPermission()` probes whether the current process has the required Administrator rights.
+- **Auto-remediation of unresolved imports**: `axon doctor --fix` automatically deletes `.conflict-*` files.
+
+### 2.2 Needs Improvement
+
+- **Symlink Integrity Audit**: Currently checks whether the destination exists, is a correct symlink, or is a real directory (hijack check). Needs standardized actionable remediation outputs (`axon link <tool>` to repair).
+- **Git Health**: Currently only verifies the existence of `.git`. We need to add checks for blocking problems: detached HEAD states and divergent branches (which prevent pulling/syncing). **Note: General uncommitted changes should NOT be checked.** Information about uncommitted changes belongs in `axon status` because they are a normal part of the development lifecycle, not a "problem" that needs fixing.
+- **Permission Sentinel**: The current global Windows check works for basic usage, but we lack specific write/symlink verification at the target link level for both Unix and Windows.
+- **`axon doctor --fix` Extension**: Currently only resolves conflicts. It must be extended to auto-remediate other safe fixes, like symlink repairs.
+- **Actionable Remediation**: Refactor inline instructions into a structured, copy-pasteable format for every diagnostic module.
+
+### 2.3 Completely Newly Add
+
+- **Binary Dependency Check**: Parse `metadata.requires.bins` in `SKILL.md` of linked skills and cross-check against `$PATH`.
+
+### 2.4 Rejected Features
+
+- **Uncommitted Changes Check**: This was initially proposed under Git Health. However, since developers frequently have uncommitted work inside the Hub during development, complaining about them in `axon doctor` creates noise. This state is strictly rotational and should continue to be exclusively surfaced via `axon status`.
+
+## 3. Proposed Solution & Architecture Options
+
+### 3.1 Refactoring Doctor Diagnostics into Modules
+
+Instead of a single heavy function, `axon doctor` will execute independent diagnostic modules. Each module returns a structured outcome:
+
+```go
+type DiagnosticResult struct {
+	Name        string
+	Passed      bool
+	ErrorMsg    string
+	Remediation string
+	CanFix      bool
+	FixAction   func() error
+}
+```
+
+### 3.2 Extending `axon doctor --fix`
+
+By capturing `CanFix` and `FixAction`, running with the `--fix` flag will iterate through failing modules whose fixes are flagged as safe/auto-remediable, and execute `FixAction()`.
+
+### 3.3 Adding the Git Checks
+
+Using `os/exec` to execute:
+
+- `git symbolic-ref -q HEAD` or `git branch --show-current` to check for detached HEAD state.
+- Check upstream tracking status for diverged branches (e.g., `git rev-list @..@{u}` and `git rev-list @{u}..@`).
+
+### 3.4 Adding Binary Dependency Parsing
+
+Parse `SKILL.md` from the Hub recursively across linked targets. Extract the YAML frontmatter, decode `requires.bins` arrays, and iterate calling `exec.LookPath(binName)`.
+
+## 4. Implementation Steps
+
+1. Refactor `runDoctor` interface to aggregate individual diagnostic modules (Symlink, Git, Windows Permissions, Binary Dependencies).
+2. Write functions for `checkGitHealth(repoPath string)`.
+3. Add a YAML unmarshaller for `SKILL.md` frontmatter and `checkSkillDependencies(repoPath, target config.Target)`.
+4. Define standard output remediation messages for broken targets.
+5. Extend `axon doctor --fix` to invoke `fixSymlink(target)` if symlink audit fails.

--- a/src/cmd/inspect.go
+++ b/src/cmd/inspect.go
@@ -53,6 +53,37 @@ type skillMeta struct {
 		Bins []string `yaml:"bins"`
 		Envs []string `yaml:"envs"`
 	} `yaml:"requires"`
+
+	// OpenClaw Metadata standard nested fields
+	Metadata struct {
+		Requires struct {
+			Bins []string `yaml:"bins"`
+		} `yaml:"requires"`
+		OpenClaw struct {
+			Requires struct {
+				Bins []string `yaml:"bins"`
+			} `yaml:"requires"`
+		} `yaml:"openclaw"`
+	} `yaml:"metadata"`
+}
+
+// GetRequiresBins merges bins from legacy format and deep metadata openclaw format
+func (m *skillMeta) GetRequiresBins() []string {
+	var bins []string
+	bins = append(bins, m.Requires.Bins...)
+	bins = append(bins, m.Metadata.Requires.Bins...)
+	bins = append(bins, m.Metadata.OpenClaw.Requires.Bins...)
+
+	// Dedupe
+	seen := make(map[string]bool)
+	var unique []string
+	for _, b := range bins {
+		if !seen[b] && b != "" {
+			seen[b] = true
+			unique = append(unique, b)
+		}
+	}
+	return unique
 }
 
 func runInspect(_ *cobra.Command, args []string) error {


### PR DESCRIPTION
## Major changes
- Refactor `doctor` command to use modular, extensible diagnostic checks
- Add checks for Git health, symlink integrity, permissions, and binary dependencies
- Replace `axon doctor fix` subcommand with `axon doctor --fix` flag for automated remediation
- Support parsing OpenClaw native metadata payload for binary requirements

## Minor improvements
- Ensure centralized Hub deduplication when reporting missing binaries
- Add detailed design doc and feature documentation for doctor enhancements
Fixes #1