### PR TITLE
feat(cli): add axon search with semantic index and dotenv config

### DIFF
--- a/docs/axon-search-design.md
+++ b/docs/axon-search-design.md
@@ -1,0 +1,353 @@
+# Design Doc: `axon search` (Local Keyword + Vector Semantic Search)
+
+## Context / Problem
+
+As users accumulate more skills in the Axon Hub, browsing manually becomes inefficient. Issue #2 proposes a new `axon search` command to find the right skill using natural language.
+
+This document defines a practical phased implementation:
+
+- Phase 1: local keyword search (zero external dependencies)
+- Phase 2: vector semantic search using precomputed embeddings synced from the Hub, plus query-time embedding generation (API) with a robust offline fallback to Phase 1
+
+## Goals
+
+- Provide a single command to discover skills by intent:
+  - `axon search "how do I analyze database perf?"`
+  - `axon search "我想制作一个ppt，哪些skill可用"`
+- Keep the client lightweight and portable:
+  - **No CGO requirement** for `axon-cli` builds.
+- Make indexing efficient and mostly centralized:
+  - Hub periodically precomputes embeddings for all skills and publishes index artifacts.
+  - Client receives those artifacts via `axon sync`.
+- Ensure good UX offline:
+  - If query-time embeddings cannot be generated (no network/no key), search still works via keyword/BM25 fallback.
+
+## Non-Goals
+
+- Running a full vector database server locally.
+- Advanced ANN indexing (HNSW/IVF). With a few hundred skills, exact similarity over all vectors is fast enough.
+- Perfect multilingual semantic retrieval without any network usage (offline embeddings can be considered later).
+
+## Key Design Decisions
+
+### 1) Exact vector search (not ANN)
+
+Given expected scale (typically **hundreds** of skills), Phase 2 will compute similarity by scanning all vectors and ranking by cosine similarity. This is simpler, deterministic, and avoids ANN complexity.
+
+### 2) Split responsibilities: Hub precomputes skill embeddings, client embeds query at runtime
+
+- Skills embeddings are precomputed centrally and distributed via Hub index artifacts.
+- Query embedding is computed at search time:
+  - Primary path: call an embeddings API once per query.
+  - Fallback: keyword/BM25 search.
+
+This minimizes API calls (only the query) and ensures the client remains small.
+
+### 3) Model consistency is mandatory
+
+Skill vectors and query vectors must be produced by the **same embedding model** (same dimension and normalization conventions), or similarity comparisons become meaningless.
+
+The synced index artifacts must include:
+
+- `model_id`
+- `dim`
+- `normalize` (boolean)
+- `index_version`
+
+## CLI / UX
+
+### Commands
+
+- `axon search <query>`
+  - Runs semantic search if query embeddings can be produced.
+  - Otherwise falls back to keyword search.
+
+- `axon search --index`
+  - Builds a **local user semantic index** under `~/.axon/search/` using the user-configured embeddings provider/model.
+  - Never writes into the synced Hub repo.
+  - If the embeddings provider is not configured, `--index` returns an actionable error.
+
+### Flags (proposed)
+
+- `--k <int>`: number of results to show (default `5`)
+- `--semantic`: force semantic search; error if semantic search cannot be performed
+- `--keyword`: force keyword/BM25 only
+- `--hybrid`: combine semantic + keyword scores (optional later)
+- `--debug`: print extra diagnostics (provider used, model id, fallback reason)
+- `--force`: rebuild index even if `hub_revision` + `text_hash` indicates no changes
+
+### Output format
+
+Example:
+
+```
+axon search "database performance"
+
+Results (3 found):
+  1. db-advisor        skills/db-advisor/        — Analyze slow queries and index usage
+  2. sql-explain       skills/sql-explain/       — Generate EXPLAIN plans for queries
+  3. pg-tuning         skills/pg-tuning/         — PostgreSQL performance tuning guide
+```
+
+## Data Sources
+
+### Skill content
+
+Indexing uses the Hub repository content:
+
+- `skills/*/SKILL.md`
+
+For each skill, the indexed text should minimally include:
+
+- Name
+- Description
+
+Optionally include:
+
+- A short set of keywords/tags
+- A small excerpt of usage/examples
+
+These fields should be concatenated into a single “embedding text” with stable formatting.
+
+## Index Artifacts (synced from Hub)
+
+The semantic index artifacts are shipped with the Hub repo and stored under the synced repo directory.
+
+- Hub repo root (after `axon sync`): `~/.axon/repo/`
+- Semantic index directory (in-repo): `~/.axon/repo/search/`
+
+### Recommended layout (applies to both Hub and user indexes)
+
+Both Hub-shipped and user-generated indexes use the same structure:
+
+- `search/index_manifest.json`
+- `search/skills.jsonl`
+- `search/vectors.f32`
+
+**Hub index location**: `~/.axon/repo/search/` (synced, read-only)
+**User index location**: `~/.axon/search/` (generated via `axon search --index`)
+
+The user index MUST NOT write into the synced Hub repo (`~/.axon/repo/`).
+
+Notes:
+
+- The user index manifest must record the same fields as the Hub manifest (`model_id`, `dim`, `normalize`, `hub_revision`, `created_at`).
+- `axon sync` updates the repo at `~/.axon/repo/` but does not touch the user index at `~/.axon/search/`.
+
+Precedence rule at query time:
+
+1. If a valid user index exists under `~/.axon/search/` and matches the current Hub `hub_revision` and embedding `model_id`, use it.
+2. Otherwise, fall back to the Hub-shipped index under `~/.axon/repo/search/`.
+
+Validity rules:
+
+- A semantic index is valid if:
+  - `index_manifest.json` exists and parses
+  - `skills.jsonl` and `vectors.f32` exist
+  - `dim` is consistent with the vector file length and the number of skills
+
+Model matching rules:
+
+- The configured query-time embeddings (`AXON_EMBEDDINGS_PROVIDER` + `AXON_EMBEDDINGS_MODEL`) MUST match the `model_id` of the selected semantic index.
+- If they do not match:
+  - Default mode (no flags): do not use semantic search; fall back to keyword search.
+  - With `--semantic`: return an error describing the mismatch.
+
+### `index_manifest.json` (example)
+
+```json
+{
+  "index_version": 1,
+  "created_at": "2026-02-28T00:00:00Z",
+  "hub_revision": "<git-sha-or-tag>",
+  "model_id": "<provider>:<model>",
+  "dim": 1024,
+  "normalize": true,
+  "vector_file": "vectors.f32",
+  "skills_file": "skills.jsonl"
+}
+```
+
+### `skills.jsonl`
+
+Each line is a JSON object:
+
+```json
+{
+  "id": "db-advisor",
+  "path": "skills/db-advisor",
+  "name": "db-advisor",
+  "description": "Analyze slow queries and index usage",
+  "text_hash": "<sha256-of-embedding-text>",
+  "updated_at": "2026-02-28T00:00:00Z"
+}
+```
+
+### `vectors.f32`
+
+Binary file storing `float32` vectors packed in row-major order:
+
+- record i occupies `dim * 4` bytes
+- skill i corresponds to the i-th line in `skills.jsonl`
+
+This format is trivial to load in pure Go (no CGO) and efficient.
+
+## Search Execution Flow
+
+### Phase 1: Keyword search
+
+Default implementation options:
+
+- Minimal: scan the parsed `name` and `description` for case-insensitive matches.
+- Improved: use BM25 via a pure-Go library, or embed Bleve (pure Go) for richer analyzers.
+
+Because Phase 1 is also the offline fallback, it should remain reliable and fast.
+
+### Phase 2: Semantic vector search
+
+Semantic execution:
+
+1. Select a semantic index using the precedence/validity rules defined in the “Index Artifacts” section.
+   - If no valid semantic index is found, fall back to Phase 1 keyword search unless `--semantic` is set.
+2. Ensure the selected semantic index is compatible with the configured `model_id`.
+2. Generate query embedding:
+   - If API key is configured and network is available, call embeddings API.
+   - Otherwise, trigger fallback to Phase 1 unless `--semantic` is set.
+3. Normalize query vector if `manifest.normalize == true`.
+4. Compute cosine similarity between query vector and each skill vector.
+5. Rank by similarity desc and return TopK.
+
+### Fallback rules
+
+- If semantic search is not possible (missing key, network error, provider error, model mismatch, missing index):
+  - Default mode (no flags): print a debug reason when `--debug` is set and run keyword/BM25 search.
+  - With `--semantic`: return an error (do not fall back).
+
+## `axon search --index` (User Index Build)
+
+### Purpose
+
+Build a local semantic index using the user-configured embeddings provider/model. This enables semantic search even when the Hub index is absent, outdated, or generated using a different model.
+
+### Inputs
+
+- Source of skills: the synced Hub repo at `~/.axon/repo/` (read-only)
+- Skill documents: `~/.axon/repo/skills/*/SKILL.md`
+- Embeddings provider configuration:
+  - `AXON_EMBEDDINGS_PROVIDER`
+  - `AXON_EMBEDDINGS_MODEL`
+  - `AXON_EMBEDDINGS_API_KEY`
+
+### Outputs
+
+Write the user index under `~/.axon/search/`:
+
+- `index_manifest.json`
+- `skills.jsonl`
+- `vectors.f32`
+
+### Invariants
+
+- The `model_id` recorded into the user manifest MUST equal the configured provider+model.
+
+### Incremental behavior
+
+Default behavior is incremental:
+
+- For each skill, compute `text_hash` from the canonical embedding text.
+- If an existing user index is present and:
+  - the repo `hub_revision` is unchanged, and
+  - the skill’s `text_hash` is unchanged,
+  then reuse the existing vector without re-embedding.
+
+Rebuild behavior:
+
+- With `--force`, recompute embeddings for all skills.
+
+### Error handling
+
+- If embeddings config is missing, return an error explaining which variables are required.
+- If embeddings calls fail mid-run:
+  - Default: fail the indexing command with a clear error.
+  - The existing user index should remain intact until a full new index is successfully written.
+
+### Atomic write strategy
+
+- Build new artifacts into a temp directory under `~/.axon/`.
+- After successful completion, atomically replace `~/.axon/search/` (rename swap).
+
+## Embeddings Provider (Query-time)
+
+Query-time embeddings should be pluggable via configuration.
+
+### Configuration
+
+The embeddings provider is configured using the following keys:
+
+- `AXON_EMBEDDINGS_PROVIDER` (e.g. `openai`, `azure-openai`, `voyage`, etc.)
+- `AXON_EMBEDDINGS_MODEL`
+- `AXON_EMBEDDINGS_API_KEY`
+
+Configuration sources and precedence:
+
+1. Process environment variables (highest priority)
+2. `~/.axon/.env` (loaded by Axon)
+
+`axon init` should generate `~/.axon/.env` as a template with the keys present but empty values, so users can fill them in when they want to use semantic search.
+
+### Multilingual requirement
+
+Because users may query in English or Chinese, the embedding model must be multilingual.
+
+## Hub-side Index Generation (out of scope for axon-cli implementation, but required contract)
+
+This section describes a possible way to ship a precomputed semantic index with the Hub repo, but it is not required to design or implement `axon search` / `axon search --index`.
+
+If a Hub index is provided, it must satisfy:
+
+- Stable ordering between `skills.jsonl` and `vectors.f32`.
+- Include `hub_revision` and `created_at`.
+- If the embedding model changes, update `model_id` and ideally bump `index_version`.
+
+## Security / Privacy Considerations
+
+- Query text will be sent to the embeddings provider when semantic search is used.
+- Skills embeddings are generated on the Hub side; clients do not send skill text to the API.
+- API keys must be read from environment or config at runtime and never stored in index artifacts.
+
+## Error Handling
+
+- If index artifacts are missing:
+  - Print guidance: run `axon sync`.
+- If model mismatch or embeddings call fails:
+  - See Fallback rules section above.
+
+## Testing Strategy
+
+- Unit tests:
+  - Parsing manifest/skills.jsonl
+  - Loading vectors.f32 and mapping to skills
+  - Cosine similarity correctness and ranking stability
+  - Fallback behavior and error messaging
+
+- Manual tests:
+  - With network + API key: semantic search returns relevant results
+  - Without network/key: keyword fallback still returns results
+
+## Acceptance Criteria Mapping (Issue #2)
+
+- Phase 1:
+  - `axon search <query>` searches `name` + `description` across all skills.
+  - Case-insensitive, supports multiple keywords.
+  - Results show skill name, path, and matched description snippet.
+
+- Phase 2:
+  - Semantic queries return ranked results by relevance.
+  - Semantic index is portable across syncs when shipped with the Hub repo.
+  - `axon search --index` builds a local user semantic index and does not overwrite the synced repo.
+
+## Open Questions
+
+1. Which embeddings provider/model should be the default for the Hub index?
+2. Should `axon-cli` support a local offline embeddings option in the future?
+3. Should we introduce a hybrid scoring mode (semantic + BM25) for improved precision?

--- a/docs/plans/2026-02-28-axon-search.md
+++ b/docs/plans/2026-02-28-axon-search.md
@@ -1,0 +1,595 @@
+# Axon Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement `axon search` (keyword + semantic vector search with offline fallback) and `axon search --index` (build user semantic index) as described in `docs/axon-search-design.md`.
+
+**Architecture:** Add a new Cobra command `search` that can (1) do keyword search by scanning skill metadata and (2) do semantic search by loading a local index (`skills.jsonl` + `vectors.f32` + `index_manifest.json`) and ranking by cosine similarity. Add an index builder for `--index` that reads skills from the synced repo, generates embeddings via a configurable provider, and writes a local user index atomically.
+
+**Tech Stack:** Go, Cobra CLI, standard library (encoding/json, os, filepath, io), existing axon config paths (`~/.axon`), HTTP client for embeddings provider.
+
+---
+
+## Milestone 0: Baseline discovery (paths, repo layout)
+
+### Task 0.1: Locate existing config/repo path helpers
+
+**Files:**
+- Inspect: `src/internal/config/*`
+- Inspect: `src/cmd/sync.go` (or equivalent)
+
+**Step 1: Search for repo/config path code**
+
+Run: `rg -n "\.axon" src/internal src/cmd src/main.go`
+
+Expected: matches for config dir and synced repo dir.
+
+**Step 2: Write down canonical helpers**
+
+- Identify functions that return:
+  - Axon config dir (e.g., `~/.axon`)
+  - Synced repo dir (e.g., `~/.axon/repo`)
+
+**Step 3: Commit (docs-only note in progress)**
+
+No code changes yet.
+
+---
+
+## Milestone 0.5: Dotenv-based embeddings configuration
+
+### Task 0.5.1: Generate `~/.axon/.env` template during `axon init`
+
+**Files:**
+- Modify: `src/cmd/init.go`
+- Modify/Inspect: `src/internal/config/*` (path helpers)
+- Test: `src/cmd/init_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestInitGeneratesDotEnvTemplate(t *testing.T) {
+    // Run axon init in a temp home/config dir sandbox
+    // Assert ~/.axon/.env exists
+    // Assert it contains the three keys with empty values
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./...`
+Expected: FAIL.
+
+**Step 3: Implement minimal template generation**
+
+Write `~/.axon/.env` with:
+
+```text
+AXON_EMBEDDINGS_PROVIDER=
+AXON_EMBEDDINGS_MODEL=
+AXON_EMBEDDINGS_API_KEY=
+```
+
+Rules:
+
+- Do not overwrite an existing `.env`.
+- If the file already exists, leave it unchanged.
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/cmd/init.go src/cmd/init_test.go
+git commit -m "feat: generate ~/.axon/.env template on axon init"
+```
+
+### Task 0.5.2: Load `~/.axon/.env` (with env var override)
+
+**Files:**
+- Create: `src/internal/config/dotenv.go`
+- Modify: `src/internal/embeddings/provider.go`
+- Test: `src/internal/config/dotenv_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestDotEnvLoadAndOverride(t *testing.T) {
+    // Create a temp .env with values
+    // Set a real env var override
+    // Expect final config uses env var when set
+}
+```
+
+**Step 2: Implement dotenv loader**
+
+Option A (preferred): use a small pure-Go dependency such as `github.com/joho/godotenv`.
+Option B: implement a minimal parser for `KEY=VALUE`.
+
+**Step 3: Wire config resolution**
+
+- When building embeddings provider config:
+  - Load `~/.axon/.env`
+  - Read final values with environment variables taking precedence
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/config/dotenv.go src/internal/config/dotenv_test.go src/internal/embeddings/provider.go
+git commit -m "feat: load ~/.axon/.env for embeddings config with env override"
+```
+
+---
+
+## Milestone 1: Keyword search (Phase 1)
+
+### Task 1.1: Add `axon search` command skeleton
+
+**Files:**
+- Create: `src/cmd/search.go`
+- Modify: `src/cmd/root.go` (or wherever commands are registered)
+
+**Step 1: Write the failing test**
+
+**Files:**
+- Create: `src/cmd/search_test.go`
+
+Add a test that runs the command with a temporary fake repo containing `skills/*/SKILL.md` and asserts output contains matched skills.
+
+```go
+func TestSearchKeywordBasic(t *testing.T) {
+    // Setup temp axon repo path with skills
+    // Run `axon search "database"`
+    // Assert output lists matching skill IDs
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./...`
+
+Expected: FAIL (missing command / missing behavior).
+
+**Step 3: Implement minimal command**
+
+- Add Cobra command `search` with args `<query>`.
+- For now, only parse args and print placeholder.
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: still FAIL (placeholder).
+
+**Step 5: Commit**
+
+```bash
+git add src/cmd/search.go src/cmd/search_test.go src/cmd/root.go
+git commit -m "feat: add axon search command scaffold"
+```
+
+### Task 1.2: Implement skill discovery + metadata parsing
+
+**Files:**
+- Modify: `src/cmd/search.go`
+- Create: `src/internal/search/skills.go`
+- Test: `src/internal/search/skills_test.go`
+
+**Step 1: Write failing tests for discovery**
+
+```go
+func TestDiscoverSkillsFindsSkillMD(t *testing.T) {
+    // create repo/skills/foo/SKILL.md
+    // expect DiscoverSkills returns foo
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./...`
+
+Expected: FAIL.
+
+**Step 3: Implement discovery**
+
+- `DiscoverSkills(repoRoot string) ([]SkillDoc, error)`
+- Read `SKILL.md` minimal fields: `name`, `description`.
+  - If SKILL.md uses frontmatter, parse it; otherwise fallback to best-effort extraction.
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/search/skills.go src/internal/search/skills_test.go src/cmd/search.go
+git commit -m "feat: discover skills and parse minimal metadata"
+```
+
+### Task 1.3: Implement keyword matching + result rendering
+
+**Files:**
+- Modify: `src/internal/search/keyword.go`
+- Modify: `src/cmd/search.go`
+- Test: `src/internal/search/keyword_test.go`
+
+**Step 1: Write failing tests**
+
+```go
+func TestKeywordSearchCaseInsensitiveMultiKeyword(t *testing.T) {
+    // query: "database perf"
+    // expect match when name/description contains both terms
+}
+```
+
+**Step 2: Implement keyword matcher**
+
+- Split query into tokens (space-separated)
+- Case-insensitive
+- Require all tokens (AND semantics)
+
+**Step 3: Implement rendering**
+
+- Print top K (default 5)
+- Show `id`, `path`, `description` (or snippet)
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/search/keyword.go src/internal/search/keyword_test.go src/cmd/search.go
+git commit -m "feat: implement keyword search and output formatting"
+```
+
+---
+
+## Milestone 2: Semantic search (Phase 2)
+
+### Task 2.1: Define index file formats + loaders
+
+**Files:**
+- Create: `src/internal/search/index/types.go`
+- Create: `src/internal/search/index/load.go`
+- Test: `src/internal/search/index/load_test.go`
+
+**Step 1: Write failing tests**
+
+- Create temp directory with:
+  - `index_manifest.json`
+  - `skills.jsonl`
+  - `vectors.f32`
+- Verify loader returns correct `[]SkillEntry` and vectors shape.
+
+**Step 2: Implement types**
+
+- `Manifest` with fields from design doc.
+- `SkillEntry` matching JSONL.
+
+**Step 3: Implement loader**
+
+- Load manifest JSON
+- Load skills JSONL
+- Load vectors as `[]float32` and validate length:
+  - `len(vectors) == len(skills) * dim`
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/search/index
+git commit -m "feat: add semantic index manifest/skills/vectors loader"
+```
+
+### Task 2.2: Implement cosine similarity ranking
+
+**Files:**
+- Create: `src/internal/search/semantic.go`
+- Test: `src/internal/search/semantic_test.go`
+
+**Step 1: Write failing tests**
+
+- Given 3 vectors and a query vector, expect ordering.
+
+**Step 2: Implement**
+
+- `CosineSim(a, b []float32) float32`
+- Optional normalization if `manifest.normalize`.
+
+**Step 3: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/internal/search/semantic.go src/internal/search/semantic_test.go
+git commit -m "feat: implement cosine similarity ranking"
+```
+
+### Task 2.3: Add embeddings provider interface (query-time)
+
+**Files:**
+- Create: `src/internal/embeddings/provider.go`
+- Create: `src/internal/embeddings/openai.go` (initial provider)
+- Test: `src/internal/embeddings/provider_test.go`
+
+**Step 1: Write failing tests**
+
+- Provider parses env vars into config.
+- Provider returns error if missing key.
+
+**Step 2: Implement provider interface**
+
+```go
+type Provider interface {
+    ModelID() string
+    Embed(ctx context.Context, text string) ([]float32, error)
+}
+```
+
+**Step 3: Implement one provider**
+
+- Implement OpenAI-compatible embeddings endpoint.
+- Parse `AXON_EMBEDDINGS_PROVIDER=openai`, `AXON_EMBEDDINGS_MODEL`, `AXON_EMBEDDINGS_API_KEY`.
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/embeddings
+git commit -m "feat: add embeddings provider interface and openai provider"
+```
+
+### Task 2.4: Wire semantic search into `axon search`
+
+**Files:**
+- Modify: `src/cmd/search.go`
+- Modify: `src/internal/search/search.go` (or create)
+- Test: `src/cmd/search_test.go`
+
+**Step 1: Write failing integration-style test**
+
+- Provide a fake semantic index on disk.
+- Stub embeddings provider to return deterministic query vector.
+- Expect semantic results order.
+
+**Step 2: Implement index selection**
+
+- Implement selection precedence:
+  - user index `~/.axon/search/`
+  - repo index `~/.axon/repo/search/`
+- Enforce `model_id` match between provider and selected index.
+
+**Step 3: Implement flags**
+
+- `--semantic`, `--no-fallback`, `--keyword`, `--k`, `--debug`
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/cmd/search.go src/cmd/search_test.go src/internal/search
+git commit -m "feat: add semantic search with fallback and flags"
+```
+
+---
+
+## Milestone 3: `axon search --index` (user index builder)
+
+### Task 3.1: Implement canonical embedding text generation
+
+**Files:**
+- Create: `src/internal/search/index/text.go`
+- Test: `src/internal/search/index/text_test.go`
+
+**Step 1: Write failing tests**
+
+- Given `SkillDoc{name, description}` produce stable canonical text.
+- Hash is stable.
+
+**Step 2: Implement**
+
+- `CanonicalText(skill SkillDoc) string`
+- `TextHash(text string) string` (sha256)
+
+**Step 3: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/internal/search/index/text.go src/internal/search/index/text_test.go
+git commit -m "feat: add canonical embedding text and text hash"
+```
+
+### Task 3.2: Implement index writer (JSONL + vectors.f32 + manifest)
+
+**Files:**
+- Create: `src/internal/search/index/write.go`
+- Test: `src/internal/search/index/write_test.go`
+
+**Step 1: Write failing tests**
+
+- Write index to temp dir.
+- Re-load it with loader and compare entries.
+
+**Step 2: Implement writer**
+
+- Write `skills.jsonl` in deterministic order.
+- Write `vectors.f32` row-major.
+- Write `index_manifest.json` with:
+  - `hub_revision` (current repo revision if available; otherwise a file hash)
+  - `created_at`
+  - `model_id`, `dim`, `normalize`
+
+**Step 3: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/internal/search/index/write.go src/internal/search/index/write_test.go
+git commit -m "feat: write semantic index artifacts"
+```
+
+### Task 3.3: Implement incremental rebuild logic
+
+**Files:**
+- Create: `src/internal/search/index/build.go`
+- Test: `src/internal/search/index/build_test.go`
+
+**Step 1: Write failing tests**
+
+- Start with existing user index.
+- Change one skill’s description.
+- Run build, ensure only one embedding call happened.
+
+**Step 2: Implement build**
+
+- Load existing user index if present.
+- Map `skill.id -> {text_hash, vector}`.
+- For each current skill:
+  - if unchanged and same `hub_revision` and no `--force`, reuse.
+  - else call provider `Embed`.
+
+**Step 3: Atomic swap**
+
+- Build to temp dir under `~/.axon/`.
+- Rename swap into `~/.axon/search/`.
+
+**Step 4: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/internal/search/index/build.go src/internal/search/index/build_test.go
+git commit -m "feat: build user semantic index incrementally with atomic swap"
+```
+
+### Task 3.4: Wire `axon search --index` command
+
+**Files:**
+- Modify: `src/cmd/search.go`
+- Test: `src/cmd/search_test.go`
+
+**Step 1: Write failing test**
+
+- Run `axon search --index` with stub provider.
+- Assert files exist under `~/.axon/search/` in temp sandbox.
+
+**Step 2: Implement**
+
+- Enforce embeddings config presence.
+- Support `--force`.
+- Print summary output (count indexed, reused, embedded).
+
+**Step 3: Run tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/cmd/search.go src/cmd/search_test.go
+git commit -m "feat: implement axon search --index"
+```
+
+---
+
+## Milestone 4: Polish + docs + manual validation
+
+### Task 4.1: Add `--debug` diagnostics + error messages
+
+**Files:**
+- Modify: `src/cmd/search.go`
+- Modify: `src/internal/search/*`
+
+**Step 1: Add debug output**
+
+- Which index selected (user vs repo)
+- Why semantic was skipped (missing key, model mismatch, missing index)
+
+**Step 2: Tests**
+
+- Update tests to assert debug info when flag set.
+
+**Step 3: Commit**
+
+```bash
+git add src/cmd/search.go src/internal/search
+git commit -m "feat: improve search diagnostics and debug output"
+```
+
+### Task 4.2: Manual test script
+
+**Files:**
+- Modify: `README.md` (optional) or `docs/NEW_FEATURES.md`
+
+**Step 1: Document usage**
+
+- `axon search "..."`
+- `axon search --index`
+- env vars required
+
+**Step 2: Commit**
+
+```bash
+git add README.md docs/NEW_FEATURES.md
+git commit -m "docs: document axon search and indexing"
+```
+
+---
+
+## Execution options
+
+Plan complete and saved to `docs/plans/2026-02-28-axon-search.md`. Two execution options:
+
+1. **Subagent-Driven (this session)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -68,6 +68,22 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	printOK("", fmt.Sprintf("Axon directory ready: %s", axonDir))
 
+	// ── 2b. Write ~/.axon/.env template if missing ────────────────────────────
+	dotEnvPath, err := config.DotEnvPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dotEnvPath); os.IsNotExist(err) {
+		if err := config.EnsureDotEnvTemplate(); err != nil {
+			return err
+		}
+		printOK("", fmt.Sprintf("Dotenv template written: %s", dotEnvPath))
+	} else if err == nil {
+		printSkip("", fmt.Sprintf("Dotenv already exists: %s", dotEnvPath))
+	} else {
+		return fmt.Errorf("cannot stat dotenv file %s: %w", dotEnvPath, err)
+	}
+
 	// ── 3. Write axon.yaml if missing ─────────────────────────────────────────
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		cfg, err := config.DefaultConfig()

--- a/src/cmd/search.go
+++ b/src/cmd/search.go
@@ -1,0 +1,286 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kamusis/axon-cli/internal/config"
+	"github.com/kamusis/axon-cli/internal/embeddings"
+	"github.com/kamusis/axon-cli/internal/search"
+	searchindex "github.com/kamusis/axon-cli/internal/search/index"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagSearchIndex    bool
+	flagSearchKeyword  bool
+	flagSearchSemantic bool
+	flagSearchK        int
+	flagSearchMinScore float64
+	flagSearchDebug    bool
+	flagSearchForce    bool
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search skills by keyword or semantic similarity",
+	Args:  cobra.MinimumNArgs(0),
+	RunE:  runSearch,
+}
+
+func init() {
+	searchCmd.Flags().BoolVar(&flagSearchIndex, "index", false, "Build/update a local semantic index (~/.axon/search)")
+	searchCmd.Flags().BoolVar(&flagSearchKeyword, "keyword", false, "Force keyword search only")
+	searchCmd.Flags().BoolVar(&flagSearchSemantic, "semantic", false, "Force semantic search only (error if unavailable)")
+	searchCmd.Flags().IntVar(&flagSearchK, "k", 5, "Number of results to show")
+	searchCmd.Flags().Float64Var(&flagSearchMinScore, "min-score", 0, "Minimum cosine similarity score to include (semantic only)")
+	searchCmd.Flags().BoolVar(&flagSearchDebug, "debug", false, "Print debug information")
+	searchCmd.Flags().BoolVar(&flagSearchForce, "force", false, "Force re-indexing even if no changes detected")
+	rootCmd.AddCommand(searchCmd)
+}
+
+func runSearch(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("cannot load config: %w\nRun 'axon init' first.", err)
+	}
+
+	minScore := resolveSemanticMinScore(cmd)
+
+	if flagSearchIndex {
+		return runSearchIndex(cmd, cfg)
+	}
+
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	query := strings.Join(args, " ")
+
+	// Keyword-only mode.
+	if flagSearchKeyword {
+		return runSearchKeyword(cfg, query)
+	}
+
+	// Default: attempt semantic; fallback to keyword on failure.
+	if flagSearchSemantic {
+		return runSearchSemanticStrict(cfg, query, minScore)
+	}
+
+	if err := runSearchSemanticBestEffort(cfg, query, minScore); err == nil {
+		return nil
+	}
+	return runSearchKeyword(cfg, query)
+}
+
+func runSearchKeyword(cfg *config.Config, query string) error {
+	skills, err := search.DiscoverSkills(cfg.RepoPath)
+	if err != nil {
+		return err
+	}
+	results := search.KeywordSearch(skills, query, flagSearchK)
+	printSearchResults(query, results)
+	return nil
+}
+
+func runSearchSemanticBestEffort(cfg *config.Config, query string, minScore float64) error {
+	res, err := semanticSearch(cfg, query, minScore)
+	if err != nil {
+		if flagSearchDebug {
+			printInfo("", fmt.Sprintf("semantic search unavailable, falling back to keyword: %v", err))
+		}
+		return err
+	}
+	printSearchResults(query, res)
+	return nil
+}
+
+func runSearchSemanticStrict(cfg *config.Config, query string, minScore float64) error {
+	res, err := semanticSearch(cfg, query, minScore)
+	if err != nil {
+		return err
+	}
+	printSearchResults(query, res)
+	return nil
+}
+
+func semanticSearch(cfg *config.Config, query string, minScore float64) ([]search.SearchResult, error) {
+	idx, idxDir, err := selectSemanticIndex(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	embCfg, err := embeddings.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	prov, err := embeddings.NewFromConfig(embCfg)
+	if err != nil {
+		return nil, err
+	}
+	if prov.ModelID() != idx.Manifest.ModelID {
+		return nil, fmt.Errorf("embeddings model mismatch: index=%s provider=%s (index dir %s)", idx.Manifest.ModelID, prov.ModelID(), idxDir)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	qv, err := prov.Embed(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(qv) != idx.Manifest.Dim {
+		return nil, fmt.Errorf("query embedding dim mismatch: got %d want %d", len(qv), idx.Manifest.Dim)
+	}
+	if idx.Manifest.Normalize {
+		qv = searchindex.NormalizeL2(qv)
+	}
+
+	results := make([]search.SearchResult, 0, len(idx.Skills))
+	for i, s := range idx.Skills {
+		start := i * idx.Manifest.Dim
+		end := start + idx.Manifest.Dim
+		sv := idx.Vectors[start:end]
+		score, err := searchindex.Cosine(qv, sv)
+		if err != nil {
+			return nil, err
+		}
+		if minScore > 0 && score < minScore {
+			continue
+		}
+		results = append(results, search.SearchResult{
+			Skill: search.SkillDoc{
+				ID:          s.ID,
+				Path:        s.Path,
+				Name:        s.Name,
+				Description: s.Description,
+			},
+			Score: score,
+			Why:   "semantic",
+		})
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no semantic results above min score %.3f", minScore)
+	}
+
+	// Sort by score desc.
+	search.SortResults(results)
+	if flagSearchK > 0 && len(results) > flagSearchK {
+		results = results[:flagSearchK]
+	}
+
+	if flagSearchDebug {
+		printInfo("", fmt.Sprintf("semantic index used: %s", idxDir))
+	}
+	return results, nil
+}
+
+func resolveSemanticMinScore(cmd *cobra.Command) float64 {
+	const defaultMinScore = 0.30
+
+	// If user explicitly sets --min-score, always honor it.
+	if cmd.Flags().Changed("min-score") {
+		return flagSearchMinScore
+	}
+
+	// If user explicitly sets --k, do not apply any default filtering.
+	if cmd.Flags().Changed("k") {
+		return 0
+	}
+
+	// Otherwise apply a default threshold to avoid irrelevant tail results.
+	return defaultMinScore
+}
+
+func selectSemanticIndex(cfg *config.Config) (*searchindex.Index, string, error) {
+	axonDir, err := config.AxonDir()
+	if err != nil {
+		return nil, "", err
+	}
+	userDir := filepath.Join(axonDir, "search")
+	repoDir := filepath.Join(cfg.RepoPath, "search")
+
+	// Prefer user index if it loads.
+	if idx, err := tryLoadIndex(userDir); err == nil {
+		return idx, userDir, nil
+	}
+	if idx, err := tryLoadIndex(repoDir); err == nil {
+		return idx, repoDir, nil
+	}
+	return nil, "", fmt.Errorf("no valid semantic index found (checked %s and %s)", userDir, repoDir)
+}
+
+func tryLoadIndex(dir string) (*searchindex.Index, error) {
+	idx, err := searchindex.Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	return idx, nil
+}
+
+func printSearchResults(query string, results []search.SearchResult) {
+	fmt.Printf("\naxon search %q\n\n", query)
+	fmt.Printf("Results (%d found):\n", len(results))
+	for i, r := range results {
+		if r.Why == "semantic" {
+			fmt.Printf("  %d. [%.3f] %-16s %-24s — %s\n", i+1, r.Score, r.Skill.ID, r.Skill.Path+"/", r.Skill.Description)
+			continue
+		}
+		fmt.Printf("  %d. %-16s %-24s — %s\n", i+1, r.Skill.ID, r.Skill.Path+"/", r.Skill.Description)
+	}
+}
+
+func runSearchIndex(cmd *cobra.Command, cfg *config.Config) error {
+	_ = cmd
+
+	// We require embeddings config for indexing.
+	embCfg, err := embeddings.LoadConfig()
+	if err != nil {
+		return err
+	}
+	prov, err := embeddings.NewFromConfig(embCfg)
+	if err != nil {
+		return err
+	}
+	if prov.ModelID() == "" {
+		return errors.New("embeddings provider is not configured")
+	}
+
+	axonDir, err := config.AxonDir()
+	if err != nil {
+		return err
+	}
+	userDir := filepath.Join(axonDir, "search")
+	tmpBase := filepath.Join(axonDir, "tmp")
+	if err := os.MkdirAll(tmpBase, 0o755); err != nil {
+		return fmt.Errorf("cannot create temp dir %s: %w", tmpBase, err)
+	}
+	tmpDir, err := os.MkdirTemp(tmpBase, "search-index-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp index dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	printInfo("", fmt.Sprintf("building semantic index using %s", prov.ModelID()))
+	_, err = searchindex.BuildUserIndex(ctx, prov, searchindex.BuildOptions{
+		RepoPath:  cfg.RepoPath,
+		OutDir:    tmpDir,
+		Force:     flagSearchForce,
+		Normalize: true,
+	})
+	if err != nil {
+		return fmt.Errorf("index build failed: %w", err)
+	}
+
+	if err := searchindex.AtomicSwap(tmpDir, userDir); err != nil {
+		return fmt.Errorf("cannot install index: %w", err)
+	}
+	printOK("", fmt.Sprintf("semantic index written: %s", userDir))
+	return nil
+}

--- a/src/internal/config/dotenv.go
+++ b/src/internal/config/dotenv.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DotEnvPath returns the absolute path to Axon's dotenv file (~/.axon/.env).
+func DotEnvPath() (string, error) {
+	axonDir, err := AxonDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(axonDir, ".env"), nil
+}
+
+// LoadDotEnv reads ~/.axon/.env and returns key/value pairs.
+//
+// Parsing rules:
+// - Lines starting with '#' are ignored.
+// - Empty lines are ignored.
+// - Lines must be of form KEY=VALUE.
+// - Whitespace around KEY is trimmed.
+// - VALUE is taken as-is (no quote parsing).
+func LoadDotEnv() (map[string]string, error) {
+	p, err := DotEnvPath()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("cannot open dotenv file %s: %w", p, err)
+	}
+	defer f.Close()
+
+	out := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		i := strings.Index(line, "=")
+		if i <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(line[:i])
+		v := line[i+1:]
+		if k == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cannot read dotenv file %s: %w", p, err)
+	}
+	return out, nil
+}
+
+// GetConfigValue returns the effective value for key, using process environment variables
+// first and falling back to ~/.axon/.env.
+func GetConfigValue(key string) (string, error) {
+	if v := os.Getenv(key); v != "" {
+		return v, nil
+	}
+	dotenv, err := LoadDotEnv()
+	if err != nil {
+		return "", err
+	}
+	return dotenv[key], nil
+}
+
+// EnsureDotEnvTemplate creates ~/.axon/.env if it does not already exist.
+//
+// The template contains configuration keys with empty values so users can fill
+// them in when they want to use embeddings-powered features.
+func EnsureDotEnvTemplate() error {
+	p, err := DotEnvPath()
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(p); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("cannot stat dotenv file %s: %w", p, err)
+	}
+
+	body := "" +
+		"AXON_EMBEDDINGS_PROVIDER=\n" +
+		"AXON_EMBEDDINGS_MODEL=\n" +
+		"AXON_EMBEDDINGS_API_KEY=\n"
+
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("cannot write dotenv template %s: %w", p, err)
+	}
+	return nil
+}

--- a/src/internal/config/dotenv_test.go
+++ b/src/internal/config/dotenv_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDotEnv_NotExist(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", t.TempDir())
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	m, err := LoadDotEnv()
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if len(m) != 0 {
+		t.Fatalf("expected empty map, got %v", m)
+	}
+}
+
+func TestLoadDotEnv_ParsesKeyValue(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	axonDir := filepath.Join(home, ".axon")
+	if err := os.MkdirAll(axonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(axonDir, ".env"), []byte("# comment\nA=1\nB=two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := LoadDotEnv()
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if m["A"] != "1" || m["B"] != "two" {
+		t.Fatalf("unexpected map: %v", m)
+	}
+}
+
+func TestGetConfigValue_EnvOverridesDotEnv(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	axonDir := filepath.Join(home, ".axon")
+	if err := os.MkdirAll(axonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(axonDir, ".env"), []byte("K=fromdotenv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// env override
+	t.Setenv("K", "fromenv")
+
+	v, err := GetConfigValue("K")
+	if err != nil {
+		t.Fatalf("GetConfigValue: %v", err)
+	}
+	if v != "fromenv" {
+		t.Fatalf("expected env override, got %q", v)
+	}
+}
+
+func TestEnsureDotEnvTemplate_DoesNotOverwrite(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	axonDir := filepath.Join(home, ".axon")
+	if err := os.MkdirAll(axonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(axonDir, ".env")
+	if err := os.WriteFile(p, []byte("AXON_EMBEDDINGS_PROVIDER=keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureDotEnvTemplate(); err != nil {
+		t.Fatalf("EnsureDotEnvTemplate: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "AXON_EMBEDDINGS_PROVIDER=keep\n" {
+		t.Fatalf("template overwrote existing file: %q", string(b))
+	}
+}
+
+func TestEnsureDotEnvTemplate_CreatesWhenMissing(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+
+	axonDir := filepath.Join(home, ".axon")
+	if err := os.MkdirAll(axonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(axonDir, ".env")
+
+	if err := EnsureDotEnvTemplate(); err != nil {
+		t.Fatalf("EnsureDotEnvTemplate: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) == 0 {
+		t.Fatalf("expected non-empty template")
+	}
+}

--- a/src/internal/embeddings/openai.go
+++ b/src/internal/embeddings/openai.go
@@ -1,0 +1,104 @@
+package embeddings
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type openAIProvider struct {
+	model   string
+	apiKey  string
+	baseURL string
+	client  *http.Client
+	dim     int
+}
+
+// NewOpenAI constructs an OpenAI-compatible embeddings provider.
+//
+// It uses the REST endpoint:
+//   POST {baseURL}/embeddings
+// with JSON body:
+//   {"model": "...", "input": "..."}
+func NewOpenAI(cfg *Config) Provider {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	return &openAIProvider{
+		model:   cfg.Model,
+		apiKey:  cfg.APIKey,
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		dim:     0,
+	}
+}
+
+func (p *openAIProvider) ModelID() string {
+	return "openai:" + p.model
+}
+
+func (p *openAIProvider) Dim() int {
+	return p.dim
+}
+
+func (p *openAIProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	if p.model == "" {
+		return nil, fmt.Errorf("embeddings model is not configured (set AXON_EMBEDDINGS_MODEL)")
+	}
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("embeddings API key is not configured (set AXON_EMBEDDINGS_API_KEY)")
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("cannot embed empty text")
+	}
+
+	reqBody := map[string]any{
+		"model": p.model,
+		"input": text,
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/embeddings", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("embeddings request failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("cannot parse embeddings response: %w", err)
+	}
+	if len(parsed.Data) == 0 || len(parsed.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("embeddings response missing embedding")
+	}
+
+	emb64 := parsed.Data[0].Embedding
+	out := make([]float32, len(emb64))
+	for i, v := range emb64 {
+		out[i] = float32(v)
+	}
+	p.dim = len(out)
+	return out, nil
+}

--- a/src/internal/embeddings/provider.go
+++ b/src/internal/embeddings/provider.go
@@ -1,0 +1,71 @@
+package embeddings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kamusis/axon-cli/internal/config"
+)
+
+// Provider embeds text into a fixed-length float vector.
+//
+// Implementations must be deterministic for the same input text and model.
+type Provider interface {
+	ModelID() string
+	Dim() int
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+// Config contains the resolved embeddings configuration.
+type Config struct {
+	Provider string
+	Model    string
+	APIKey   string
+	BaseURL  string
+}
+
+// LoadConfig resolves embeddings config from environment variables first, then ~/.axon/.env.
+func LoadConfig() (*Config, error) {
+	provider, err := config.GetConfigValue("AXON_EMBEDDINGS_PROVIDER")
+	if err != nil {
+		return nil, err
+	}
+	model, err := config.GetConfigValue("AXON_EMBEDDINGS_MODEL")
+	if err != nil {
+		return nil, err
+	}
+	apiKey, err := config.GetConfigValue("AXON_EMBEDDINGS_API_KEY")
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := config.GetConfigValue("AXON_EMBEDDINGS_BASE_URL")
+	if err != nil {
+		return nil, err
+	}
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+
+	return &Config{
+		Provider: provider,
+		Model:    model,
+		APIKey:   apiKey,
+		BaseURL:  baseURL,
+	}, nil
+}
+
+// NewFromConfig returns an embeddings provider.
+func NewFromConfig(cfg *Config) (Provider, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("embeddings config is nil")
+	}
+	if cfg.Provider == "" {
+		return nil, fmt.Errorf("embeddings provider is not configured (set AXON_EMBEDDINGS_PROVIDER)")
+	}
+	switch cfg.Provider {
+	case "openai":
+		return NewOpenAI(cfg), nil
+	default:
+		return nil, fmt.Errorf("unsupported embeddings provider: %s", cfg.Provider)
+	}
+}

--- a/src/internal/search/frontmatter.go
+++ b/src/internal/search/frontmatter.go
@@ -1,0 +1,37 @@
+package search
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type frontmatterDoc map[string]string
+
+func splitFrontmatter(content string) (map[string]string, string) {
+	s := strings.TrimPrefix(content, "\ufeff")
+	if !strings.HasPrefix(s, "---") {
+		return map[string]string{}, content
+	}
+
+	parts := strings.SplitN(s, "---", 3)
+	if len(parts) < 3 {
+		return map[string]string{}, content
+	}
+
+	fmText := strings.TrimSpace(parts[1])
+	body := strings.TrimPrefix(parts[2], "\n")
+
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(fmText), &raw); err != nil {
+		return map[string]string{}, content
+	}
+
+	out := make(map[string]string)
+	for k, v := range raw {
+		if sv, ok := v.(string); ok {
+			out[strings.ToLower(k)] = sv
+		}
+	}
+	return out, body
+}

--- a/src/internal/search/index/build.go
+++ b/src/internal/search/index/build.go
@@ -1,0 +1,150 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/kamusis/axon-cli/internal/embeddings"
+	"github.com/kamusis/axon-cli/internal/search"
+)
+
+// BuildOptions controls user index building.
+type BuildOptions struct {
+	RepoPath  string
+	OutDir    string
+	Force     bool
+	Normalize bool
+}
+
+// BuildUserIndex builds a semantic index from skills found in repoPath and writes it to outDir.
+//
+// The build is incremental when an existing index is present in outDir (unless Force is true).
+// It is the caller's responsibility to apply an atomic swap strategy.
+func BuildUserIndex(ctx context.Context, prov embeddings.Provider, opts BuildOptions) (*Index, error) {
+	if opts.RepoPath == "" {
+		return nil, fmt.Errorf("repo path is required")
+	}
+	if opts.OutDir == "" {
+		return nil, fmt.Errorf("out dir is required")
+	}
+
+	skills, err := search.DiscoverSkills(opts.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(skills) == 0 {
+		return nil, fmt.Errorf("no skills found under %s", opts.RepoPath)
+	}
+
+	sort.Slice(skills, func(i, j int) bool { return skills[i].ID < skills[j].ID })
+
+	// Load existing index for reuse.
+	old, _ := Load(opts.OutDir)
+	reuse := map[string]SkillEntry{}
+	reuseVec := map[string][]float32{}
+	if old != nil && !opts.Force {
+		for i, se := range old.Skills {
+			start := i * old.Manifest.Dim
+			end := start + old.Manifest.Dim
+			if start >= 0 && end <= len(old.Vectors) {
+				reuse[se.ID] = se
+				v := make([]float32, old.Manifest.Dim)
+				copy(v, old.Vectors[start:end])
+				reuseVec[se.ID] = v
+			}
+		}
+	}
+
+	var (
+		entries []SkillEntry
+		vectors []float32
+		dim     int
+	)
+
+	for _, s := range skills {
+		text := CanonicalText(s)
+		h := TextHash(text)
+
+		if old != nil && !opts.Force {
+			if prev, ok := reuse[s.ID]; ok {
+				if prev.TextHash == h && prev.TextHash != "" {
+					if v, ok := reuseVec[s.ID]; ok {
+						entries = append(entries, prev)
+						vectors = append(vectors, v...)
+						if dim == 0 {
+							dim = len(v)
+						}
+						continue
+					}
+				}
+			}
+		}
+
+		emb, err := prov.Embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		if dim == 0 {
+			dim = len(emb)
+		}
+		if len(emb) != dim {
+			return nil, fmt.Errorf("embedding dim changed mid-run: got %d want %d", len(emb), dim)
+		}
+		if opts.Normalize {
+			emb = NormalizeL2(emb)
+		}
+
+		entries = append(entries, SkillToEntry(s, h))
+		vectors = append(vectors, emb...)
+	}
+
+	manifest := Manifest{
+		IndexVersion: 1,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		HubRevision:  "",
+		ModelID:      prov.ModelID(),
+		Dim:          dim,
+		Normalize:    opts.Normalize,
+		VectorFile:   "vectors.f32",
+		SkillsFile:   "skills.jsonl",
+	}
+
+	idx := &Index{Manifest: manifest, Skills: entries, Vectors: vectors}
+
+	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+		return nil, fmt.Errorf("cannot create out dir: %w", err)
+	}
+	if err := Write(opts.OutDir, manifest, entries, vectors); err != nil {
+		return nil, err
+	}
+
+	return idx, nil
+}
+
+// AtomicSwap replaces destDir with srcDir by renaming.
+func AtomicSwap(srcDir, destDir string) error {
+	parent := filepath.Dir(destDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	backup := destDir + ".bak"
+	_ = os.RemoveAll(backup)
+	if _, err := os.Stat(destDir); err == nil {
+		if err := os.Rename(destDir, backup); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(srcDir, destDir); err != nil {
+		// rollback best-effort
+		if _, stErr := os.Stat(backup); stErr == nil {
+			_ = os.Rename(backup, destDir)
+		}
+		return err
+	}
+	_ = os.RemoveAll(backup)
+	return nil
+}

--- a/src/internal/search/index/errors.go
+++ b/src/internal/search/index/errors.go
@@ -1,0 +1,6 @@
+package index
+
+import "errors"
+
+// ErrVectorLengthMismatch indicates two vectors have different dimensions.
+var ErrVectorLengthMismatch = errors.New("vector length mismatch")

--- a/src/internal/search/index/load.go
+++ b/src/internal/search/index/load.go
@@ -1,0 +1,100 @@
+package index
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Load reads an index from dir containing manifest + skills + vectors.
+func Load(dir string) (*Index, error) {
+	manifestPath := filepath.Join(dir, "index_manifest.json")
+	b, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read manifest %s: %w", manifestPath, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("invalid manifest JSON %s: %w", manifestPath, err)
+	}
+	if m.Dim <= 0 {
+		return nil, fmt.Errorf("invalid dim in manifest: %d", m.Dim)
+	}
+	if m.VectorFile == "" {
+		m.VectorFile = "vectors.f32"
+	}
+	if m.SkillsFile == "" {
+		m.SkillsFile = "skills.jsonl"
+	}
+
+	skills, err := loadSkills(filepath.Join(dir, m.SkillsFile))
+	if err != nil {
+		return nil, err
+	}
+	vectors, err := loadVectors(filepath.Join(dir, m.VectorFile), len(skills), m.Dim)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := &Index{Manifest: m, Skills: skills, Vectors: vectors}
+	return idx, nil
+}
+
+func loadSkills(path string) ([]SkillEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open skills file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var out []SkillEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e SkillEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			return nil, fmt.Errorf("invalid skills JSONL %s: %w", path, err)
+		}
+		out = append(out, e)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cannot read skills file %s: %w", path, err)
+	}
+	return out, nil
+}
+
+func loadVectors(path string, nSkills, dim int) ([]float32, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open vector file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat vector file %s: %w", path, err)
+	}
+	if st.Size()%4 != 0 {
+		return nil, fmt.Errorf("vector file size is not multiple of 4 bytes: %d", st.Size())
+	}
+
+	expected := int64(nSkills * dim * 4)
+	if expected != st.Size() {
+		return nil, fmt.Errorf("vector file size mismatch: got %d want %d (skills=%d dim=%d)", st.Size(), expected, nSkills, dim)
+	}
+
+	nFloats := nSkills * dim
+	out := make([]float32, nFloats)
+
+	if err := binary.Read(io.LimitReader(f, expected), binary.LittleEndian, out); err != nil {
+		return nil, fmt.Errorf("cannot read vectors from %s: %w", path, err)
+	}
+	return out, nil
+}

--- a/src/internal/search/index/load_test.go
+++ b/src/internal/search/index/load_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_IndexHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	m := Manifest{
+		IndexVersion: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+		HubRevision:  "rev",
+		ModelID:      "openai:test",
+		Dim:          2,
+		Normalize:    true,
+		VectorFile:   "vectors.f32",
+		SkillsFile:   "skills.jsonl",
+	}
+	mb, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(dir, "index_manifest.json"), mb, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := []SkillEntry{
+		{ID: "a", Path: "skills/a", Name: "a", Description: "A"},
+		{ID: "b", Path: "skills/b", Name: "b", Description: "B"},
+	}
+	var skillsLines []byte
+	for _, s := range skills {
+		b, _ := json.Marshal(s)
+		skillsLines = append(skillsLines, b...)
+		skillsLines = append(skillsLines, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skills.jsonl"), skillsLines, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vecFile, err := os.Create(filepath.Join(dir, "vectors.f32"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectors := []float32{1, 0, 0, 1}
+	if err := binary.Write(vecFile, binary.LittleEndian, vectors); err != nil {
+		_ = vecFile.Close()
+		t.Fatal(err)
+	}
+	_ = vecFile.Close()
+
+	idx, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if idx.Manifest.Dim != 2 {
+		t.Fatalf("dim mismatch")
+	}
+	if len(idx.Skills) != 2 {
+		t.Fatalf("skills mismatch")
+	}
+	if len(idx.Vectors) != 4 {
+		t.Fatalf("vectors mismatch")
+	}
+}

--- a/src/internal/search/index/text.go
+++ b/src/internal/search/index/text.go
@@ -1,0 +1,27 @@
+package index
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/kamusis/axon-cli/internal/search"
+)
+
+// CanonicalText returns the canonical text used for embeddings generation.
+func CanonicalText(s search.SkillDoc) string {
+	parts := []string{
+		"name: " + strings.TrimSpace(s.Name),
+		"description: " + strings.TrimSpace(s.Description),
+	}
+	if strings.TrimSpace(s.Keywords) != "" {
+		parts = append(parts, "keywords: "+strings.TrimSpace(s.Keywords))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// TextHash returns a sha256 hash (hex) of the canonical text.
+func TextHash(text string) string {
+	h := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(h[:])
+}

--- a/src/internal/search/index/types.go
+++ b/src/internal/search/index/types.go
@@ -1,0 +1,30 @@
+package index
+
+// Manifest describes a semantic index and how to interpret it.
+type Manifest struct {
+	IndexVersion int    `json:"index_version"`
+	CreatedAt    string `json:"created_at"`
+	HubRevision  string `json:"hub_revision"`
+	ModelID      string `json:"model_id"`
+	Dim          int    `json:"dim"`
+	Normalize    bool   `json:"normalize"`
+	VectorFile   string `json:"vector_file"`
+	SkillsFile   string `json:"skills_file"`
+}
+
+// SkillEntry represents one skill row in skills.jsonl.
+type SkillEntry struct {
+	ID          string `json:"id"`
+	Path        string `json:"path"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	TextHash    string `json:"text_hash"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// Index is a loaded semantic index.
+type Index struct {
+	Manifest Manifest
+	Skills   []SkillEntry
+	Vectors  []float32
+}

--- a/src/internal/search/index/vector.go
+++ b/src/internal/search/index/vector.go
@@ -1,0 +1,45 @@
+package index
+
+import "math"
+
+// Cosine computes cosine similarity between two vectors of equal length.
+func Cosine(a, b []float32) (float64, error) {
+	if len(a) != len(b) {
+		return 0, ErrVectorLengthMismatch
+	}
+	var dot float64
+	var na float64
+	var nb float64
+	for i := 0; i < len(a); i++ {
+		x := float64(a[i])
+		y := float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	den := math.Sqrt(na) * math.Sqrt(nb)
+	if den == 0 {
+		return 0, nil
+	}
+	return dot / den, nil
+}
+
+// NormalizeL2 returns a new vector normalized to unit L2 norm.
+func NormalizeL2(v []float32) []float32 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	n := math.Sqrt(sum)
+	if n == 0 {
+		out := make([]float32, len(v))
+		copy(out, v)
+		return out
+	}
+	out := make([]float32, len(v))
+	inv := float32(1.0 / n)
+	for i := range v {
+		out[i] = v[i] * inv
+	}
+	return out
+}

--- a/src/internal/search/index/write.go
+++ b/src/internal/search/index/write.go
@@ -1,0 +1,104 @@
+package index
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kamusis/axon-cli/internal/search"
+)
+
+// Write writes index artifacts to dir.
+func Write(dir string, manifest Manifest, skills []SkillEntry, vectors []float32) error {
+	if manifest.Dim <= 0 {
+		return fmt.Errorf("invalid dim: %d", manifest.Dim)
+	}
+	if len(skills) == 0 {
+		return fmt.Errorf("no skills to write")
+	}
+	if len(vectors) != len(skills)*manifest.Dim {
+		return fmt.Errorf("vector length mismatch: got %d want %d", len(vectors), len(skills)*manifest.Dim)
+	}
+	if manifest.VectorFile == "" {
+		manifest.VectorFile = "vectors.f32"
+	}
+	if manifest.SkillsFile == "" {
+		manifest.SkillsFile = "skills.jsonl"
+	}
+	if manifest.CreatedAt == "" {
+		manifest.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("cannot create index dir %s: %w", dir, err)
+	}
+
+	// manifest
+	mb, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index_manifest.json"), mb, 0o644); err != nil {
+		return fmt.Errorf("cannot write manifest: %w", err)
+	}
+
+	// skills jsonl
+	sf, err := os.Create(filepath.Join(dir, manifest.SkillsFile))
+	if err != nil {
+		return fmt.Errorf("cannot create skills file: %w", err)
+	}
+	bw := bufio.NewWriter(sf)
+	for _, s := range skills {
+		line, err := json.Marshal(s)
+		if err != nil {
+			_ = sf.Close()
+			return err
+		}
+		if _, err := bw.Write(line); err != nil {
+			_ = sf.Close()
+			return err
+		}
+		if err := bw.WriteByte('\n'); err != nil {
+			_ = sf.Close()
+			return err
+		}
+	}
+	if err := bw.Flush(); err != nil {
+		_ = sf.Close()
+		return err
+	}
+	if err := sf.Close(); err != nil {
+		return err
+	}
+
+	// vectors
+	vf, err := os.Create(filepath.Join(dir, manifest.VectorFile))
+	if err != nil {
+		return fmt.Errorf("cannot create vectors file: %w", err)
+	}
+	if err := binary.Write(vf, binary.LittleEndian, vectors); err != nil {
+		_ = vf.Close()
+		return fmt.Errorf("cannot write vectors: %w", err)
+	}
+	if err := vf.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SkillToEntry converts SkillDoc to SkillEntry for index writing.
+func SkillToEntry(s search.SkillDoc, textHash string) SkillEntry {
+	return SkillEntry{
+		ID:          s.ID,
+		Path:        s.Path,
+		Name:        s.Name,
+		Description: s.Description,
+		TextHash:    textHash,
+		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+}

--- a/src/internal/search/keyword.go
+++ b/src/internal/search/keyword.go
@@ -1,0 +1,57 @@
+package search
+
+import (
+	"sort"
+	"strings"
+)
+
+// KeywordSearch searches skills by case-insensitive keyword matching over name, description,
+// and keywords. All query tokens must match (AND semantics).
+func KeywordSearch(skills []SkillDoc, query string, limit int) []SearchResult {
+	tokens := tokenize(query)
+	if len(tokens) == 0 {
+		return []SearchResult{}
+	}
+
+	var out []SearchResult
+	for _, s := range skills {
+		blob := strings.ToLower(strings.Join([]string{s.ID, s.Name, s.Description, s.Keywords}, "\n"))
+		ok := true
+		for _, tok := range tokens {
+			if !strings.Contains(blob, tok) {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		out = append(out, SearchResult{Skill: s, Score: 1, Why: "keyword"})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Skill.ID < out[j].Skill.ID
+	})
+
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func tokenize(q string) []string {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return nil
+	}
+	parts := strings.Fields(q)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/src/internal/search/skills.go
+++ b/src/internal/search/skills.go
@@ -1,0 +1,92 @@
+package search
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DiscoverSkills scans repoRoot/skills/*/SKILL.md and returns parsed SkillDoc entries.
+func DiscoverSkills(repoRoot string) ([]SkillDoc, error) {
+	skillsDir := filepath.Join(repoRoot, "skills")
+	info, err := os.Stat(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []SkillDoc{}, nil
+		}
+		return nil, fmt.Errorf("cannot stat skills directory %s: %w", skillsDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("skills path is not a directory: %s", skillsDir)
+	}
+
+	var out []SkillDoc
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(repoRoot, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		id := filepath.Base(filepath.Dir(path))
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("cannot read %s: %w", path, err)
+		}
+		h, body := splitFrontmatter(string(b))
+
+		name := strings.TrimSpace(h["name"])
+		desc := strings.TrimSpace(h["description"])
+		keywords := strings.TrimSpace(h["keywords"])
+		if keywords == "" {
+			keywords = strings.TrimSpace(h["tags"])
+		}
+
+		if name == "" {
+			name = id
+		}
+		if desc == "" {
+			desc = inferDescriptionFromBody(body)
+		}
+
+		out = append(out, SkillDoc{
+			ID:          id,
+			Path:        filepath.ToSlash(rel),
+			Name:        name,
+			Description: desc,
+			Keywords:    keywords,
+		})
+		return nil
+	}
+
+	if err := filepath.WalkDir(skillsDir, walkFn); err != nil {
+		return nil, fmt.Errorf("cannot scan skills: %w", err)
+	}
+	return out, nil
+}
+
+func inferDescriptionFromBody(body string) string {
+	lines := strings.Split(body, "\n")
+	for _, ln := range lines {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		if strings.HasPrefix(ln, "#") {
+			continue
+		}
+		return ln
+	}
+	return ""
+}

--- a/src/internal/search/skills_test.go
+++ b/src/internal/search/skills_test.go
@@ -1,0 +1,34 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverSkills_ParsesFrontmatter(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	skillDir := filepath.Join(repo, "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: demo-skill\ndescription: Hello world\n---\n\n# Body\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skills, err := DiscoverSkills(repo)
+	if err != nil {
+		t.Fatalf("DiscoverSkills: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	if skills[0].Name != "demo-skill" {
+		t.Fatalf("unexpected name: %q", skills[0].Name)
+	}
+	if skills[0].Description != "Hello world" {
+		t.Fatalf("unexpected description: %q", skills[0].Description)
+	}
+}

--- a/src/internal/search/sort.go
+++ b/src/internal/search/sort.go
@@ -1,0 +1,13 @@
+package search
+
+import "sort"
+
+// SortResults sorts results by score (descending), then by skill ID (ascending).
+func SortResults(results []SearchResult) {
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].Skill.ID < results[j].Skill.ID
+		}
+		return results[i].Score > results[j].Score
+	})
+}

--- a/src/internal/search/types.go
+++ b/src/internal/search/types.go
@@ -1,0 +1,17 @@
+package search
+
+// SkillDoc represents the minimal searchable metadata for a skill.
+type SkillDoc struct {
+	ID          string
+	Path        string
+	Name        string
+	Description string
+	Keywords    string
+}
+
+// SearchResult represents one matched skill.
+type SearchResult struct {
+	Skill SkillDoc
+	Score float64
+	Why   string
+}


### PR DESCRIPTION
## Summary
Adds a new `axon search` command with keyword and semantic (vector) search, plus a local user index builder.

## Major changes
- Add `axon search` CLI command with:
  - default semantic -> keyword fallback
  - `--keyword` keyword-only
  - `--semantic` strict semantic-only
  - `--k`, `--min-score`, and cosine score display for semantic results
- Implement `axon search --index` to build/update a local semantic index under `~/.axon/search` with atomic install and incremental reuse
- Add OpenAI-compatible embeddings provider configured via env / `~/.axon/.env`
- Implement skill discovery + YAML frontmatter parsing + keyword search
- Implement semantic index format + loader + writer + cosine similarity ranking

## Notes
- `axon init` now creates a `~/.axon/.env` template (without overwriting).
- Client remains no-CGO; semantic search uses exact cosine over vectors.

## Verification
- `go test ./...`