### PR TITLE
feat(cli): add rollback command and status updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 
 # ── Release artifacts (GoReleaser) ────────────────────────────────────────────
 dist/
+
+# ── Communities Promotion ─────────────────────────────────────────────────────
+/communities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Test
+
+All commands run from the `src/` directory:
+
+```bash
+cd src
+
+# Build
+go build -o axon .
+
+# Run all tests
+go test ./...
+
+# Run tests for a specific package
+go test ./cmd/...
+go test ./internal/config/...
+go test ./internal/search/...
+
+# Run a single test
+go test ./cmd/ -run TestRollback
+
+# Install locally
+go build -o axon . && sudo mv axon /usr/local/bin/
+```
+
+Releases are built via GoReleaser (triggered on `v*` tags via GitHub Actions).
+
+## Architecture
+
+**Axon** is a hub-and-spoke skill manager: a single Git-backed Hub at `~/.axon/repo/` stores `skills/`, `workflows/`, and `commands/` directories, and symlinks connect each AI editor's config dirs to the Hub.
+
+### Code layout
+
+```
+src/
+  main.go                    # entry point, calls cmd.Execute()
+  cmd/                       # cobra subcommands (one file per command)
+    root.go                  # rootCmd, -v/--version flag, Execute()
+    git_utils.go             # shared git helpers (gitRun, gitOutput, gitIsDirty, resolveSkillPath, gitCommitInfo, gitLogEntries, gitCurrentSHA, etc.)
+    output.go                # printOK / printWarn / printInfo / printSkip helpers
+    init.go                  # axon init (bootstrap Hub, import existing skills)
+    link.go / unlink.go      # symlink management + backup/restore
+    sync.go                  # read-write and read-only sync modes
+    status.go                # symlink health check + git status + per-skill status
+    rollback.go              # skill-level and hub-wide rollback via git
+    remote.go                # axon remote set
+    doctor.go                # pre-flight env checks
+    search.go                # keyword + semantic search frontend
+    inspect.go               # skill metadata inspection
+    update.go                # self-update from GitHub releases
+    version.go               # version string
+  internal/
+    config/
+      config.go              # Config struct, Load/Save, DefaultConfig, ExpandPath
+      dotenv.go              # .env file loader for embeddings config
+    importer/
+      importer.go            # skill import logic (MD5 dedup, conflict naming)
+    embeddings/
+      provider.go            # embeddings provider interface
+      openai.go              # OpenAI embeddings implementation
+    search/
+      keyword.go             # keyword (BM25-like) search
+      skills.go              # skill document walker
+      frontmatter.go         # YAML frontmatter parser for skill files
+      index/                 # semantic index (build, load, vector storage)
+```
+
+### Key design patterns
+
+**Config** (`internal/config/Config`): loaded from `~/.axon/axon.yaml` at the start of most commands. `RepoPath` is always `~`-expanded at load time. `Targets` drive both symlink management and `EffectiveSearchRoots()`.
+
+**Git operations**: all git calls go through helpers in `cmd/git_utils.go`. `gitRun()` streams output; `gitOutput()` captures it. Commands call `checkGitAvailable()` before touching git.
+
+**Sync flow** (`cmd/sync.go`):
+- Writes excludes to `.git/info/exclude` (not `.gitignore`)
+- Strips nested `.git` dirs from skills before `git add`
+- `read-write`: add → commit → pull `--rebase -X theirs` → push (fallback to merge)
+- `read-only`: pull `--ff-only` only
+
+**Rollback** (`cmd/rollback.go`): refuses to run on a dirty repo. Both modes create a **forward commit** (never rewrite history) so `axon sync` can propagate the rollback safely. Skill rollback uses `git checkout <sha> -- <path>` + `git commit`; hub-wide uses `git revert --no-commit <range>` + `git commit` (squashed into one commit). `resolveSkillPath` in `git_utils.go` resolves shorthand skill names (e.g. `"humanizer"` → `"skills/humanizer"`).
+
+**Search**: two modes — keyword (offline) and semantic (requires embeddings config via env or `~/.axon/.env`). Semantic index stored in `~/.axon/search/`. `axon search` tries semantic first and falls back to keyword.
+
+**Output conventions**: use `printOK`, `printWarn`, `printInfo`, `printSkip` from `cmd/output.go` for consistent terminal output. Errors are returned (not printed) and surfaced by `Execute()`.
+
+## Module
+
+The Go module is `github.com/kamusis/axon-cli` (in `src/go.mod`). Key dependencies: `cobra` (CLI), `yaml.v3` (config), `flock` (file locking for self-update).

--- a/README.md
+++ b/README.md
@@ -47,19 +47,20 @@ axon sync
 
 ## Commands
 
-| Command                   | Description                                           |
-| ------------------------- | ----------------------------------------------------- |
-| `axon init [repo-url]`    | Bootstrap the Hub; import existing skills             |
-| `axon link [name\|all]`   | Create symlinks from tool dirs to the Hub             |
-| `axon unlink [name\|all]` | Remove symlinks; restore backups if available         |
-| `axon sync`               | Commit → pull → push (or pull-only in read-only mode) |
-| `axon remote set <url>`   | Set or update the Hub's git remote origin URL         |
-| `axon status [--fetch]`   | Validate symlinks + show Hub git status               |
-| `axon doctor`             | Pre-flight environment check                          |
-| `axon search <query>`     | Search skills/workflows/commands (keyword + semantic) |
-| `axon inspect <skill>`    | Show metadata and structure of a skill                |
-| `axon update`             | Self-update axon to the latest GitHub release         |
-| `axon version`            | Show detailed version/build/runtime info              |
+| Command                        | Description                                           |
+| ------------------------------ | ----------------------------------------------------- |
+| `axon init [repo-url]`         | Bootstrap the Hub; import existing skills             |
+| `axon link [name\|all]`        | Create symlinks from tool dirs to the Hub             |
+| `axon unlink [name\|all]`      | Remove symlinks; restore backups if available         |
+| `axon sync`                    | Commit → pull → push (or pull-only in read-only mode) |
+| `axon remote set <url>`        | Set or update the Hub's git remote origin URL         |
+| `axon status [skill-name]`     | Validate symlinks + Hub git status; or show skill history |
+| `axon rollback <skill\|--all>` | Revert a skill or the entire Hub to a previous commit |
+| `axon doctor`                  | Pre-flight environment check                          |
+| `axon search <query>`          | Search skills/workflows/commands (keyword + semantic) |
+| `axon inspect <skill>`         | Show metadata and structure of a skill                |
+| `axon update`                  | Self-update axon to the latest GitHub release         |
+| `axon version`                 | Show detailed version/build/runtime info              |
 
 Global flags:
 
@@ -154,6 +155,67 @@ To prevent cross-platform CRLF/LF churn, `axon init` also writes a default `.git
 Add `--fetch` to also fetch `origin` and show whether your local Hub branch is ahead/behind the remote default branch. If the remote is newer, run `axon sync` to pull updates.
 
 If `origin/HEAD` is missing, re-run `axon remote set <url>` to initialize the remote default branch reference.
+
+Pass an optional `skill-name` to switch to **skill-level inspection mode** — shows the skill's resolved path, whether it is currently linked, and its recent commit history:
+
+```bash
+axon status humanizer
+axon status humanizer --fetch   # also show remote ahead/behind count for this skill
+```
+
+```
+=== Skill: humanizer ===
+  Path:    /home/user/.axon/repo/skills/humanizer
+  Linked:  ✓
+
+● Recent commits:
+  #1   abc1234  2026-03-05 14:20   axon: sync from mac-mini
+  #2   def5678  2026-03-04 10:15   axon: sync from vps-1
+```
+
+### `axon rollback`
+
+`axon rollback` reverts a skill directory or the entire Hub to a previous commit **without requiring any Git knowledge**. It always creates a new forward commit (never rewrites history), so `axon sync` can safely propagate the rollback to all your machines.
+
+```bash
+# Revert one skill to the previous commit
+axon rollback humanizer
+
+# Revert one skill to a specific commit
+axon rollback humanizer --revision abc1234
+
+# Revert the entire Hub one commit back
+axon rollback --all
+
+# Revert the entire Hub to a specific commit
+axon rollback --all --revision abc1234
+```
+
+The command prints a summary before acting:
+
+```
+[ Rollback ]
+  Skill:   humanizer
+  Current: axon: sync from mac-mini (2026-03-05 14:20)
+  Target:  axon: sync from vps-1   (2026-03-04 10:15)
+
+  Reverting skills/humanizer... DONE
+✓ Skill "humanizer" rolled back to def5678. Run 'axon sync' to propagate.
+```
+
+**Key behaviours:**
+
+- Refuses to run if the Hub has uncommitted changes — commit or stash first.
+- Use `axon status <skill-name>` to browse recent commits and find a target SHA before rolling back.
+- Running `axon rollback` twice on the same target cancels out (the second run reverts the first). To go back multiple steps, use `--revision <sha>` to target a specific commit directly.
+- After rolling back, run `axon sync` to push the revert commit to your remote and pull it on other machines.
+
+Flags:
+
+| Flag | Description |
+|---|---|
+| `--all` | Revert the entire Hub (mutually exclusive with a skill name) |
+| `--revision <sha>` | Target a specific Git SHA, tag, or branch instead of the previous commit |
 
 ### `axon inspect` — Skill Metadata
 

--- a/docs/axon-rollback-implementation-plan.md
+++ b/docs/axon-rollback-implementation-plan.md
@@ -1,0 +1,159 @@
+# Axon Rollback Implementation Plan
+
+Implement a new `axon rollback` command (issue #11) that lets users revert a skill or the entire Hub to a previous Git state without needing Git knowledge.
+
+Based on design review: **history/inspection belongs in `axon status`**, not in `rollback`. The rollback command is purely for rollback. `axon status` is extended to accept an optional `[skill-name]` argument that shows skill-level info including recent commit history.
+
+## Proposed Changes
+
+### `cmd` package
+
+#### [NEW] [rollback.go](src/cmd/rollback.go)
+
+A single new file- **[NEW]** `cmd/rollback.go` — implements `rollback` and shared Git/Path helpers.
+
+- **[MODIFY]** `cmd/status.go` — extends `status` to support skill-level inspection.
+- **[MODIFY]** `cmd/rollback_test.go` — verification for both commands and path resolution.
+
+**Cobra command structure:**
+
+```bash
+axon rollback <skill-name>                       # roll back one skill one commit
+axon rollback <skill> --revision <sha-or-tag>    # roll back skill to exact revision
+axon rollback --all                              # roll back entire Hub one commit
+axon rollback --all --revision <sha-or-tag>      # reset entire Hub to exact revision
+```
+
+### `cmd/rollback.go`
+
+- `rollbackCmd`: Definition with `--all` and `--revision` flags.
+- `runRollback`: Main entry point with dirty-check and resolution logic.
+- `rollbackSkill(repoPath, skillName, revision)`: Reverts a skill by checking out target SHA and committing.
+- `rollbackHubAll(repoPath, revision)`: Resets the entire Hub using `reset --hard`.
+- **`resolveSkillPath(repoPath, name)`**: Checks if `name` exists at root, or in `skills/`, `workflows/`, or `commands/`. Returns the relative path.
+- `gitCommitInfo`, `gitLogEntries`: Helpers for formatted Git output.
+
+Flags registered (all on the `rollback` sub-command):
+| Flag | Type | Description |
+|---|---|---|
+| `--all` | bool | Roll back entire Hub (not a single skill) |
+| `--revision` | string | Target Git SHA, tag, or branch |
+
+**`runRollback` — argument / flag validation:**
+
+- `--all` and a skill name are mutually exclusive.
+- `--revision` is valid with either a skill name **or** `--all`.
+- No skill name + no `--all` → error with usage hint.
+
+**`rollbackSkill(repo, skillPath, targetSHA)` helper (core action):**
+
+1. **Safety check**: call `gitIsDirty(repo)` (already in `sync.go`); if dirty, **hard-fail** with an error — `"uncommitted changes in Hub, please commit or stash first"`. No prompt.
+2. Find `targetSHA` if not provided:
+   - If `--revision` given: use as-is.
+   - Default: `git log --skip=1 -1 --format=%H -- <path>` (the commit before HEAD).
+3. If no `targetSHA` found → error "no previous version found for skill".
+4. Show summary block (matching issue example output exactly):
+
+   ```
+   [ Rollback ]
+     Skill: <name>
+     Current: <current-commit-subject> (<YYYY-MM-DD HH:MM>)
+     Target:  <target-commit-subject>  (<YYYY-MM-DD HH:MM>)
+
+     Reverting skills/<name>... DONE
+     ✓ Skill '<name>' rolled back one version. Run 'axon sync' to propagate.
+   ```
+
+   Timestamps are fetched via `git log --format=%cd --date=format:'%Y-%m-%d %H:%M'`.
+
+5. `git checkout <targetSHA> -- <skillPath>` to restore the tree.
+6. `git add <skillPath>` then `git commit -m "axon: rollback <skill> to <sha-short>"`.
+
+**`rollbackAll(repo, targetSHA string)` helper:**
+
+1. **Safety check**: same hard-fail on dirty repo as `rollbackSkill`.
+2. `git log --oneline -2` to show current + target.
+3. If last commit is NOT an `axon:` commit, warn the user.
+4. Create a **forward revert commit** (never rewrite history — sync-safe):
+   - Without `--revision`: `git revert HEAD --no-edit` — creates one new commit that undoes HEAD.
+   - With `--revision <sha>`: `git revert --no-commit <sha>..HEAD` then
+     `git commit -m "axon: rollback hub to <sha-short>"` — stages all intermediate reversals
+     as a single squashed commit, restoring the tree to the state at `<sha>`.
+5. Print confirmation.
+
+> **Design rationale:** `git reset --hard` is intentionally avoided. It rewrites local history,
+> which causes `axon sync` (which runs `git pull --rebase`) to silently re-apply the removed
+> commits from origin, undoing the rollback. Using `git revert` keeps history linear and
+> forward-only, so sync can push the revert commit to origin and propagate it to other machines.
+> Running `rollback --all` twice will cancel out (same as `rollback <skill>` twice); users who
+> need to go back N steps should use `--revision <sha>` to target a specific commit.
+
+**Shared helpers (new, private to rollback.go):**
+
+- `gitLogPath(repo, path, skip, n int) ([]logEntry, error)` — parses `git log --format=%H|%ar|%s`.
+- `gitCurrentSHA(repo) (string, error)` — `git rev-parse --short HEAD`.
+
+**Output conventions** — reuse existing helpers from `output.go`: `printSection`, `printOK`, `printWarn`, `printInfo`, `printErr`.
+
+---
+
+#### [MODIFY] [status.go](src/cmd/status.go)
+
+Extend `runStatus` to accept an optional positional argument `[skill-name]`.
+
+- **No argument** (existing behaviour unchanged): symlink health + Hub git status.
+- **With `skill-name`**: show a focused skill info block. `--fetch` is already a flag on `statusCmd` and applies here too:
+
+  ```
+  === Skill: humanizer ===
+    Path:    /path/to/hub/skills/humanizer
+    Linked:  ✓  (or ✗ not linked)
+
+  ● Recent commits:
+    #1  abc1234  2026-03-05 14:20   axon: sync from mac-mini
+    #2  def5678  2026-03-04 10:15   axon: sync from vps-1
+  ```
+
+  With `--fetch`: after the commit list, add a remote comparison line (reusing the same `git rev-list --left-right --count` logic already in `runStatus`), scoped to commits touching `-- <skillPath>`:
+
+  ```
+    Remote: origin/master  (skill ahead 0 / behind 1)
+  ```
+
+Implementation: add `Args: cobra.MaximumNArgs(1)` to `statusCmd` and branch at the top of `runStatus` on `len(args) == 1` to call a new private `showSkillStatus(cfg, skillName string, fetchFirst bool) error` helper.
+
+---
+
+#### [NEW] [rollback_test.go](src/cmd/rollback_test.go)
+
+New test file in `cmd/` using the same `initTestRepo(t)` helper from `sync_test.go`.
+
+| Test                                | What it covers                                                                                                   |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `TestRollbackSkill_PreviousVersion` | After two commits to `skills/foo`, `rollbackSkill` restores the first version's content and creates a new commit |
+| `TestRollbackSkill_NoHistory`       | Rolling back a skill never touched before returns an error                                                       |
+| `TestRollbackAll`                   | After two commits, `rollbackAll` creates a new revert commit; HEAD moves forward by 1 and file content matches the pre-rollback-target state |
+| `TestRollbackSkill_WithRevision`    | `--revision HEAD~1` rolls back to the specified SHA                                                              |
+| `TestShowSkillStatus`               | After two commits touching a skill path, `showSkillStatus` output contains the skill path and ≥1 commit entry    |
+
+---
+
+## Verification Plan
+
+### Automated Tests
+
+```bash
+cd src
+go test ./cmd/... -v -run TestRollback
+go test ./cmd/... -v -run TestShowSkillStatus
+go test ./...
+go build ./...
+```
+
+### Manual Smoke Test
+
+1. `axon status humanizer` — should show the skill path, link state, and a numbered recent-commit table.
+2. `axon rollback humanizer` — should print the `[ Rollback ]` summary block, then `✓ ... rolled back`.
+3. `git log --oneline -3` in the Hub repo — should show a new `axon: rollback humanizer to <sha>` commit on top.
+4. `axon rollback --all` — should create a new revert commit on top of HEAD; `git log --oneline -3` should show the new `axon: rollback hub to <sha>` commit, and file content should reflect the previous version.
+5. `axon rollback humanizer --revision HEAD~2` — should roll back to a specific SHA.

--- a/docs/axon-rollback-implementation-plan.md
+++ b/docs/axon-rollback-implementation-plan.md
@@ -29,7 +29,7 @@ axon rollback --all --revision <sha-or-tag>      # reset entire Hub to exact rev
 - `rollbackCmd`: Definition with `--all` and `--revision` flags.
 - `runRollback`: Main entry point with dirty-check and resolution logic.
 - `rollbackSkill(repoPath, skillName, revision)`: Reverts a skill by checking out target SHA and committing.
-- `rollbackHubAll(repoPath, revision)`: Resets the entire Hub using `reset --hard`.
+- `rollbackHubAll(repoPath, revision)`: Reverts the Hub using `git revert` (forward revert commits; no history rewrite).
 - **`resolveSkillPath(repoPath, name)`**: Checks if `name` exists at root, or in `skills/`, `workflows/`, or `commands/`. Returns the relative path.
 - `gitCommitInfo`, `gitLogEntries`: Helpers for formatted Git output.
 

--- a/src/cmd/git_utils.go
+++ b/src/cmd/git_utils.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// resolveSkillPath finds a skill/workflow/command by its shorthand name.
+// Examples: "humanizer" -> "skills/humanizer", "git-release" -> "workflows/git-release".
+// If multiple matches exist, it returns an error.
+func resolveSkillPath(repoPath, name string) (string, error) {
+	// 1. Direct match (absolute or already relative).
+	full := filepath.Join(repoPath, name)
+	if _, err := os.Stat(full); err == nil {
+		return name, nil
+	}
+
+	// 2. Search in common directories.
+	prefixes := []string{"skills", "workflows", "commands"}
+	var matches []string
+	for _, p := range prefixes {
+		candidate := filepath.Join(p, name)
+		fullCand := filepath.Join(repoPath, candidate)
+		if _, err := os.Stat(fullCand); err == nil {
+			matches = append(matches, candidate)
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("cannot find skill, workflow, or command %q in Hub", name)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("ambiguous name %q matches multiple paths:\n  - %s\nPlease specify the full relative path.",
+			name, strings.Join(matches, "\n  - "))
+	}
+
+	return matches[0], nil
+}
+
+// ── Git Helpers ─────────────────────────────────────────────────────────────
+
+// checkGitAvailable returns a clear error if git is not found on PATH.
+func checkGitAvailable() error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("git is not installed or not on PATH\n" +
+			"  Axon requires git to manage the Hub repository.\n" +
+			"  Install git from https://git-scm.com and try again.")
+	}
+	return nil
+}
+
+// gitRun executes a git sub-command and streams output to stdout/stderr.
+func gitRun(args ...string) error {
+	c := exec.Command("git", args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// gitOutput runs a git sub-command and returns its combined stdout output.
+func gitOutput(repoPath string, args ...string) (string, error) {
+	fullArgs := append([]string{"-C", repoPath}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+// gitIsDirty reports whether the repo has uncommitted changes.
+func gitIsDirty(repoPath string) (bool, error) {
+	out, err := gitOutput(repoPath, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("git status: %w", err)
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// gitHasRemote reports whether the repo has any remote configured.
+func gitHasRemote(repoPath string) bool {
+	out, err := gitOutput(repoPath, "remote")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// gitRemoteIsEmpty reports whether the remote has no refs at all (i.e. it is a
+// brand-new empty repository that has never received a push).
+func gitRemoteIsEmpty(repoPath string) bool {
+	out, err := gitOutput(repoPath, "ls-remote", "--heads", "origin")
+	if err != nil {
+		// ls-remote failure (e.g. auth error) — treat as non-empty to be safe.
+		return false
+	}
+	return strings.TrimSpace(out) == ""
+}
+
+// gitConfigValue returns the value of a git config key.
+func gitConfigValue(repoPath, key string) (string, error) {
+	out, err := gitOutput(repoPath, "config", "--get", key)
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// gitIdentityConfigured checks if both user.name and user.email are set.
+func gitIdentityConfigured(repoPath string) (bool, error) {
+	name, err := gitConfigValue(repoPath, "user.name")
+	if err != nil {
+		return false, err
+	}
+	email, err := gitConfigValue(repoPath, "user.email")
+	if err != nil {
+		return false, err
+	}
+	return name != "" && email != "", nil
+}
+
+// commitInfo holds the one-line summary and formatted date of a commit.
+type commitInfo struct {
+	sha     string // abbreviated (7-char)
+	fullSHA string // full 40-char SHA
+	subject string
+	date    string
+}
+
+// gitCommitInfo returns subject + author-date for a given commit and optional
+// path filter.
+func gitCommitInfo(repoPath, ref, path string) (commitInfo, error) {
+	args := []string{"log", ref, "-1", "--format=%H|%s|%cd", "--date=format:%Y-%m-%d %H:%M"}
+	if path != "" {
+		args = append(args, "--", path)
+	}
+	out, err := gitOutput(repoPath, args...)
+	if err != nil || strings.TrimSpace(out) == "" {
+		return commitInfo{}, fmt.Errorf("no commit info for %q (path=%q): %w", ref, path, err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(out), "|", 3)
+	if len(parts) != 3 {
+		return commitInfo{}, fmt.Errorf("unexpected git log output: %q", out)
+	}
+	short := parts[0]
+	if len(short) > 7 {
+		short = short[:7]
+	}
+	return commitInfo{sha: short, fullSHA: parts[0], subject: parts[1], date: parts[2]}, nil
+}
+
+// gitLogEntries returns up to n commit log entries for a path in the repo,
+// skipping the first skip entries. Use skip=0 for no skipping.
+func gitLogEntries(repoPath, path string, skip, n int) ([]commitInfo, error) {
+	args := []string{"log"}
+	if skip > 0 {
+		args = append(args, fmt.Sprintf("--skip=%d", skip))
+	}
+	args = append(args, fmt.Sprintf("-n%d", n), "--format=%H|%s|%cd", "--date=format:%Y-%m-%d %H:%M")
+	if path != "" {
+		args = append(args, "--", path)
+	}
+	out, err := gitOutput(repoPath, args...)
+	if err != nil {
+		return nil, fmt.Errorf("git log: %w", err)
+	}
+	var entries []commitInfo
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		short := parts[0]
+		if len(short) > 7 {
+			short = short[:7]
+		}
+		entries = append(entries, commitInfo{sha: short, fullSHA: parts[0], subject: parts[1], date: parts[2]})
+	}
+	return entries, nil
+}
+
+// gitCurrentSHA returns the abbreviated SHA of HEAD.
+func gitCurrentSHA(repoPath string) (string, error) {
+	out, err := gitOutput(repoPath, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/src/cmd/git_utils.go
+++ b/src/cmd/git_utils.go
@@ -105,7 +105,12 @@ func gitRemoteIsEmpty(repoPath string) bool {
 func gitConfigValue(repoPath, key string) (string, error) {
 	out, err := gitOutput(repoPath, "config", "--get", key)
 	if err != nil {
-		return "", nil
+		// `git config --get` exits with 1 if the key is not found.
+		// Treat that case as an empty value, but propagate other errors.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", err
 	}
 	return strings.TrimSpace(out), nil
 }

--- a/src/cmd/rollback.go
+++ b/src/cmd/rollback.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kamusis/axon-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback [skill-name]",
+	Short: "Roll back a skill or the entire Hub to a previous Git state",
+	Long: `Roll back a skill directory or the entire Hub to a previous commit.
+
+Examples:
+  axon rollback humanizer                    # revert humanizer to the previous commit
+  axon rollback humanizer --revision abc123  # revert humanizer to a specific SHA
+  axon rollback --all                        # revert entire Hub one commit back
+  axon rollback --all --revision abc123      # revert entire Hub to a specific SHA
+
+The command refuses to run if there are uncommitted changes in the Hub.
+After rolling back, run 'axon sync' to propagate the change to other machines.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRollback,
+}
+
+var (
+	rollbackAll      bool
+	rollbackRevision string
+)
+
+func init() {
+	rollbackCmd.Flags().BoolVar(&rollbackAll, "all", false, "Roll back the entire Hub (not a single skill)")
+	rollbackCmd.Flags().StringVar(&rollbackRevision, "revision", "", "Target Git SHA, tag, or branch")
+	rootCmd.AddCommand(rollbackCmd)
+}
+
+func runRollback(cmd *cobra.Command, args []string) error {
+	if err := checkGitAvailable(); err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("cannot load config: %w\nRun 'axon init' first.", err)
+	}
+
+	// Validate flag combinations.
+	if rollbackAll && len(args) > 0 {
+		return fmt.Errorf("--all and a skill name are mutually exclusive")
+	}
+	if !rollbackAll && len(args) == 0 {
+		return fmt.Errorf("specify a skill name or use --all\n\n  axon rollback <skill>          # revert one skill\n  axon rollback --all            # revert entire Hub")
+	}
+
+	// Safety: refuse to operate on a dirty repo.
+	dirty, err := gitIsDirty(cfg.RepoPath)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("uncommitted changes in Hub — please commit or stash first\n  Run: git -C %s status", cfg.RepoPath)
+	}
+
+	if rollbackAll {
+		return rollbackHubAll(cfg.RepoPath, rollbackRevision)
+	}
+	return rollbackSkill(cfg.RepoPath, args[0], rollbackRevision)
+}
+
+// rollbackSkill reverts a single skill directory to a previous commit.
+func rollbackSkill(repoPath, skillName, revision string) error {
+	// Resolve the skill path relative to the repo root.
+	skillPath, err := resolveSkillPath(repoPath, skillName)
+	if err != nil {
+		return err
+	}
+
+	// Determine the target SHA.
+	var targetSHA string
+	if revision != "" {
+		// Validate that the revision exists.
+		sha, err := gitOutput(repoPath, "rev-parse", "--verify", revision+"^{commit}")
+		if err != nil {
+			return fmt.Errorf("unknown revision %q: %w", revision, err)
+		}
+		targetSHA = strings.TrimSpace(sha)
+	} else {
+		// Default: the commit just before the most recent commit touching this skill.
+		entries, err := gitLogEntries(repoPath, skillPath, 1, 1)
+		if err != nil || len(entries) == 0 {
+			return fmt.Errorf("no previous version found for skill %q\n  (It may have only one commit, or the path may be incorrect.)", skillName)
+		}
+		targetSHA = entries[0].fullSHA
+	}
+
+	// Fetch commit info for Current and Target.
+	currentInfo, err := gitCommitInfo(repoPath, "HEAD", skillPath)
+	if err != nil {
+		return fmt.Errorf("cannot read current commit info: %w", err)
+	}
+	targetInfo, err := gitCommitInfo(repoPath, targetSHA, skillPath)
+	if err != nil {
+		return fmt.Errorf("cannot read target commit info: %w", err)
+	}
+
+	// Print the summary block.
+	fmt.Println("\n[ Rollback ]")
+	fmt.Printf("  Skill:   %s\n", skillName)
+	fmt.Printf("  Current: %s (%s)\n", currentInfo.subject, currentInfo.date)
+	fmt.Printf("  Target:  %s (%s)\n", targetInfo.subject, targetInfo.date)
+	fmt.Println()
+	fmt.Printf("  Reverting %s...", skillPath)
+
+	// Restore the skill tree to the target SHA.
+	if err := gitRun("-C", repoPath, "checkout", targetSHA, "--", skillPath); err != nil {
+		fmt.Println(" FAILED")
+		return fmt.Errorf("git checkout failed: %w", err)
+	}
+	fmt.Println(" DONE")
+
+	// Create a rollback commit.
+	shortSHA := targetSHA
+	if len(shortSHA) > 7 {
+		shortSHA = shortSHA[:7]
+	}
+	msg := fmt.Sprintf("axon: rollback %s to %s", skillName, shortSHA)
+	if err := gitRun("-C", repoPath, "add", skillPath); err != nil {
+		return fmt.Errorf("git add failed: %w", err)
+	}
+	if err := gitRun("-C", repoPath, "commit", "-m", msg); err != nil {
+		return fmt.Errorf("git commit failed: %w", err)
+	}
+
+	printOK("", fmt.Sprintf("Skill %q rolled back to %s. Run 'axon sync' to propagate.", skillName, shortSHA))
+	return nil
+}
+
+// ── Hub-wide rollback ─────────────────────────────────────────────────────────
+
+// rollbackHubAll reverts the entire Hub to the state before HEAD (or before a
+// specific revision) by creating a new forward revert commit — never rewriting
+// history, so axon sync can safely push the result to origin.
+func rollbackHubAll(repoPath, revision string) error {
+	// Determine the target state (the commit whose content we want to restore).
+	var targetSHA string
+	if revision != "" {
+		sha, err := gitOutput(repoPath, "rev-parse", "--verify", revision+"^{commit}")
+		if err != nil {
+			return fmt.Errorf("unknown revision %q: %w", revision, err)
+		}
+		targetSHA = strings.TrimSpace(sha)
+	} else {
+		sha, err := gitOutput(repoPath, "rev-parse", "HEAD~1")
+		if err != nil {
+			return fmt.Errorf("cannot resolve HEAD~1 (Hub may have only one commit): %w", err)
+		}
+		targetSHA = strings.TrimSpace(sha)
+	}
+
+	shortSHA := targetSHA
+	if len(shortSHA) > 7 {
+		shortSHA = shortSHA[:7]
+	}
+
+	// Show what we're about to do.
+	currentInfo, err := gitCommitInfo(repoPath, "HEAD", "")
+	if err != nil {
+		return fmt.Errorf("cannot read current commit info: %w", err)
+	}
+	targetInfo, err := gitCommitInfo(repoPath, targetSHA, "")
+	if err != nil {
+		return fmt.Errorf("cannot read target commit info: %w", err)
+	}
+
+	// Warn if the last commit isn't an axon: commit (i.e. user-made).
+	if !strings.HasPrefix(currentInfo.subject, "axon:") {
+		printWarn("", fmt.Sprintf("Current HEAD is a non-axon commit: %q", currentInfo.subject))
+		printWarn("", "Reverting it will undo its changes.")
+	}
+
+	fmt.Println("\n[ Rollback Hub ]")
+	fmt.Printf("  Current: %s (%s)\n", currentInfo.subject, currentInfo.date)
+	fmt.Printf("  Target:  %s (%s)\n", targetInfo.subject, targetInfo.date)
+	fmt.Println()
+	fmt.Print("  Reverting Hub...")
+
+	// Build the revert range:
+	//   default:      revert only HEAD         → "HEAD"
+	//   --revision:   revert targetSHA..HEAD   → all commits above targetSHA
+	revertRange := "HEAD"
+	if revision != "" {
+		revertRange = targetSHA + "..HEAD"
+	}
+
+	// Stage the reversal(s) without committing so we can write a custom message.
+	if err := gitRun("-C", repoPath, "revert", "--no-commit", revertRange); err != nil {
+		fmt.Println(" FAILED")
+		_ = gitRun("-C", repoPath, "revert", "--abort")
+		return fmt.Errorf("git revert failed: %w\n  (A conflict may have occurred; the revert has been aborted.)", err)
+	}
+
+	msg := fmt.Sprintf("axon: rollback hub to %s", shortSHA)
+	if err := gitRun("-C", repoPath, "commit", "-m", msg); err != nil {
+		fmt.Println(" FAILED")
+		_ = gitRun("-C", repoPath, "revert", "--abort")
+		return fmt.Errorf("git commit failed: %w", err)
+	}
+	fmt.Println(" DONE")
+
+	if sha, err := gitCurrentSHA(repoPath); err == nil {
+		printOK("", fmt.Sprintf("Hub rolled back to %s. Run 'axon sync' to propagate.", sha))
+	} else {
+		printOK("", "Hub rolled back. Run 'axon sync' to propagate.")
+	}
+	return nil
+}

--- a/src/cmd/rollback_test.go
+++ b/src/cmd/rollback_test.go
@@ -1,0 +1,407 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// addSkillCommit writes content to a file inside skillPath in the repo and
+// commits it with the given message.
+func addSkillCommit(t *testing.T, repoPath, skillPath, content, msg string) {
+	t.Helper()
+	full := filepath.Join(repoPath, skillPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", repoPath, "add", skillPath},
+		{"-C", repoPath, "commit", "-m", msg},
+	} {
+		if err := gitRun(args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+}
+
+// commitCount returns the number of commits in the repo HEAD log.
+func commitCount(t *testing.T, repoPath string) int {
+	t.Helper()
+	out, err := gitOutput(repoPath, "rev-list", "--count", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-list --count: %v", err)
+	}
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d", &n); err != nil {
+		t.Fatalf("parse commit count %q: %v", out, err)
+	}
+	return n
+}
+
+// ── rollbackSkill tests ───────────────────────────────────────────────────────
+
+func TestRollbackSkill_PreviousVersion(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// Two commits touching the same skill file.
+	addSkillCommit(t, repo, "skills/foo/SKILL.md", "version 1\n", "axon: sync from host1")
+	addSkillCommit(t, repo, "skills/foo/SKILL.md", "version 2\n", "axon: sync from host2")
+
+	countBefore := commitCount(t, repo)
+
+	if err := rollbackSkill(repo, "skills/foo/SKILL.md", ""); err != nil {
+		t.Fatalf("rollbackSkill: %v", err)
+	}
+
+	// A new commit should have been created.
+	countAfter := commitCount(t, repo)
+	if countAfter != countBefore+1 {
+		t.Errorf("expected %d commits after rollback, got %d", countBefore+1, countAfter)
+	}
+
+	// The file content should be restored to version 1.
+	data, err := os.ReadFile(filepath.Join(repo, "skills/foo/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "version 1" {
+		t.Errorf("expected 'version 1' after rollback, got %q", string(data))
+	}
+
+	// The new commit message should contain "rollback".
+	logOut, _ := gitOutput(repo, "log", "--oneline", "-1")
+	if !strings.Contains(logOut, "rollback") {
+		t.Errorf("expected rollback commit message, got: %s", logOut)
+	}
+}
+
+func TestRollbackSkill_NoHistory(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+
+	// Skill was never committed — only one (initial) commit exists.
+	err := rollbackSkill(cfg.RepoPath, "skills/nonexistent/SKILL.md", "")
+	if err == nil {
+		t.Fatal("expected error for skill with no history, got nil")
+	}
+}
+
+func TestRollbackSkill_WithRevision(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// Three commits: v1, v2, v3.
+	addSkillCommit(t, repo, "skills/bar/SKILL.md", "v1\n", "axon: sync v1")
+	sha1, _ := gitOutput(repo, "rev-parse", "HEAD")
+	sha1 = strings.TrimSpace(sha1)
+	addSkillCommit(t, repo, "skills/bar/SKILL.md", "v2\n", "axon: sync v2")
+	addSkillCommit(t, repo, "skills/bar/SKILL.md", "v3\n", "axon: sync v3")
+
+	// Roll back explicitly to the sha1 commit.
+	if err := rollbackSkill(repo, "skills/bar/SKILL.md", sha1); err != nil {
+		t.Fatalf("rollbackSkill --revision: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo, "skills/bar/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "v1" {
+		t.Errorf("expected 'v1' after rollback to sha1, got %q", string(data))
+	}
+}
+
+func TestRollbackSkill_InvalidRevision(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	addSkillCommit(t, repo, "skills/inv/SKILL.md", "v1\n", "axon: sync v1")
+
+	err := rollbackSkill(repo, "skills/inv/SKILL.md", "deadbeefdeadbeef")
+	if err == nil {
+		t.Fatal("expected error for invalid revision, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown revision") {
+		t.Errorf("expected 'unknown revision' in error, got: %v", err)
+	}
+}
+
+func TestRollbackSkill_Shorthand(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// Two commits using a fully-qualified path; rollback via shorthand name.
+	addSkillCommit(t, repo, "skills/shorthand/SKILL.md", "v1\n", "axon: sync v1")
+	addSkillCommit(t, repo, "skills/shorthand/SKILL.md", "v2\n", "axon: sync v2")
+
+	// "shorthand" should resolve to "skills/shorthand" via resolveSkillPath.
+	if err := rollbackSkill(repo, "shorthand", ""); err != nil {
+		t.Fatalf("rollbackSkill with shorthand name: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo, "skills/shorthand/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "v1" {
+		t.Errorf("expected 'v1' after shorthand rollback, got %q", string(data))
+	}
+}
+
+// ── rollbackHubAll tests ──────────────────────────────────────────────────────
+
+func TestRollbackAll(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// Two commits: v1 then v2.
+	addSkillCommit(t, repo, "skills/baz/SKILL.md", "v1\n", "axon: sync baz v1")
+	addSkillCommit(t, repo, "skills/baz/SKILL.md", "v2\n", "axon: sync baz v2")
+	countBefore := commitCount(t, repo)
+
+	if err := rollbackHubAll(repo, ""); err != nil {
+		t.Fatalf("rollbackHubAll: %v", err)
+	}
+
+	// A new revert commit should have been created (HEAD moves forward by 1).
+	countAfter := commitCount(t, repo)
+	if countAfter != countBefore+1 {
+		t.Errorf("expected %d commits after rollback, got %d", countBefore+1, countAfter)
+	}
+
+	// File content should be reverted to v1.
+	data, err := os.ReadFile(filepath.Join(repo, "skills/baz/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "v1" {
+		t.Errorf("expected 'v1' after hub rollback, got %q", string(data))
+	}
+
+	// The new commit message should contain "rollback".
+	logOut, _ := gitOutput(repo, "log", "--oneline", "-1")
+	if !strings.Contains(logOut, "rollback") {
+		t.Errorf("expected rollback commit message, got: %s", logOut)
+	}
+}
+
+func TestRollbackAll_SingleCommit(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	// initTestRepo creates exactly one commit; HEAD~1 does not exist.
+	err := rollbackHubAll(cfg.RepoPath, "")
+	if err == nil {
+		t.Fatal("expected error when Hub has only one commit, got nil")
+	}
+}
+
+func TestRollbackAll_WithRevision(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// Three commits: initial + v1 + v2.
+	addSkillCommit(t, repo, "skills/rev/SKILL.md", "v1\n", "axon: sync v1")
+	sha1, _ := gitOutput(repo, "rev-parse", "HEAD")
+	sha1 = strings.TrimSpace(sha1)
+	addSkillCommit(t, repo, "skills/rev/SKILL.md", "v2\n", "axon: sync v2")
+	countBefore := commitCount(t, repo)
+
+	// Roll back hub to sha1 (reverting v2).
+	if err := rollbackHubAll(repo, sha1); err != nil {
+		t.Fatalf("rollbackHubAll --revision: %v", err)
+	}
+
+	// A single squashed revert commit should have been created.
+	countAfter := commitCount(t, repo)
+	if countAfter != countBefore+1 {
+		t.Errorf("expected %d commits after hub rollback --revision, got %d", countBefore+1, countAfter)
+	}
+
+	// File content should be back to v1.
+	data, err := os.ReadFile(filepath.Join(repo, "skills/rev/SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "v1" {
+		t.Errorf("expected 'v1' after hub rollback to sha1, got %q", string(data))
+	}
+
+	// Commit message should reference "rollback".
+	logOut, _ := gitOutput(repo, "log", "--oneline", "-1")
+	if !strings.Contains(logOut, "rollback") {
+		t.Errorf("expected rollback in commit message, got: %s", logOut)
+	}
+}
+
+func TestRollbackAll_InvalidRevision(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	err := rollbackHubAll(cfg.RepoPath, "deadbeefdeadbeef")
+	if err == nil {
+		t.Fatal("expected error for invalid revision, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown revision") {
+		t.Errorf("expected 'unknown revision' in error, got: %v", err)
+	}
+}
+
+// ── showSkillStatus tests ─────────────────────────────────────────────────────
+
+func TestShowSkillStatus(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	addSkillCommit(t, repo, "skills/qux/SKILL.md", "hello\n", "axon: sync qux")
+	addSkillCommit(t, repo, "skills/qux/SKILL.md", "world\n", "axon: sync qux again")
+
+	// Capture stdout to assert output content.
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := showSkillStatus(cfg, "skills/qux/SKILL.md", false)
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	out := buf.String()
+
+	if err != nil {
+		t.Fatalf("showSkillStatus: %v", err)
+	}
+	if !strings.Contains(out, "skills/qux/SKILL.md") {
+		t.Errorf("expected output to contain skill path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "axon: sync qux") {
+		t.Errorf("expected output to contain at least one commit entry, got:\n%s", out)
+	}
+}
+
+// ── gitLogEntries tests ───────────────────────────────────────────────────────
+
+func TestGitLogEntries(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	addSkillCommit(t, repo, "skills/log/SKILL.md", "a\n", "axon: commit 1")
+	addSkillCommit(t, repo, "skills/log/SKILL.md", "b\n", "axon: commit 2")
+
+	entries, err := gitLogEntries(repo, "skills/log/SKILL.md", 0, 10)
+	if err != nil {
+		t.Fatalf("gitLogEntries: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("expected at least 2 log entries, got %d", len(entries))
+	}
+	// Most recent first.
+	if !strings.Contains(entries[0].subject, "commit 2") {
+		t.Errorf("expected most recent commit first, got subject %q", entries[0].subject)
+	}
+	// fullSHA must be populated and longer than the abbreviated sha.
+	if entries[0].fullSHA == "" {
+		t.Error("expected non-empty fullSHA in log entry")
+	}
+	if len(entries[0].fullSHA) <= len(entries[0].sha) {
+		t.Errorf("fullSHA (%q) should be longer than abbreviated sha (%q)", entries[0].fullSHA, entries[0].sha)
+	}
+}
+
+func TestGitLogEntries_Skip(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	addSkillCommit(t, repo, "skills/skip/SKILL.md", "a\n", "axon: commit 1")
+	addSkillCommit(t, repo, "skills/skip/SKILL.md", "b\n", "axon: commit 2")
+	addSkillCommit(t, repo, "skills/skip/SKILL.md", "c\n", "axon: commit 3")
+
+	// skip=1 should exclude the most recent commit and return commits 2 and 1.
+	entries, err := gitLogEntries(repo, "skills/skip/SKILL.md", 1, 10)
+	if err != nil {
+		t.Fatalf("gitLogEntries skip=1: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries with skip=1, got %d", len(entries))
+	}
+	if !strings.Contains(entries[0].subject, "commit 2") {
+		t.Errorf("expected 'commit 2' as first entry after skip=1, got %q", entries[0].subject)
+	}
+	if !strings.Contains(entries[1].subject, "commit 1") {
+		t.Errorf("expected 'commit 1' as second entry after skip=1, got %q", entries[1].subject)
+	}
+}
+
+// ── gitCurrentSHA tests ───────────────────────────────────────────────────────
+
+func TestGitCurrentSHA(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	sha, err := gitCurrentSHA(cfg.RepoPath)
+	if err != nil {
+		t.Fatalf("gitCurrentSHA: %v", err)
+	}
+	if len(sha) == 0 || len(sha) > 10 {
+		t.Errorf("expected abbreviated SHA (1-10 chars), got %q", sha)
+	}
+	for _, c := range sha {
+		if !strings.ContainsRune("0123456789abcdef", c) {
+			t.Errorf("SHA contains non-hex character %q in %q", c, sha)
+			break
+		}
+	}
+}
+
+// ── resolveSkillPath tests ───────────────────────────────────────────────────
+
+func TestResolveSkillPath(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+	repo := cfg.RepoPath
+
+	// 1. Setup Hub structure
+	dirs := []string{
+		"skills/foo",
+		"workflows/bar",
+		"commands/baz",
+		"skills/collision",
+		"workflows/collision",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(repo, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		want     string
+		wantErr  bool
+		errMatch string
+	}{
+		{"shorthand skill", "foo", "skills/foo", false, ""},
+		{"shorthand workflow", "bar", "workflows/bar", false, ""},
+		{"shorthand command", "baz", "commands/baz", false, ""},
+		{"direct match", "skills/foo", "skills/foo", false, ""},
+		{"collision", "collision", "", true, "ambiguous"},
+		{"not found", "nonexistent", "", true, "cannot find"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSkillPath(repo, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveSkillPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMatch != "" && !strings.Contains(err.Error(), tt.errMatch) {
+				t.Errorf("resolveSkillPath() error = %v, want matching %q", err, tt.errMatch)
+			}
+			if got != tt.want {
+				t.Errorf("resolveSkillPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -37,29 +36,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagVersion, "version", "v", false, "Print axon version and exit")
 }
 
-// checkGitAvailable returns a clear error if git is not found on PATH.
-func checkGitAvailable() error {
-	if _, err := exec.LookPath("git"); err != nil {
-		return fmt.Errorf("git is not installed or not on PATH\n" +
-			"  Axon requires git to manage the Hub repository.\n" +
-			"  Install git from https://git-scm.com and try again.")
-	}
-	return nil
-}
-
 // Execute is called by main.go.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-// gitRun executes a git sub-command and streams output to stdout/stderr.
-// It is a thin convenience wrapper used by multiple commands.
-func gitRun(args ...string) error {
-	c := exec.Command("git", args...)
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	return c.Run()
 }

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -14,8 +14,9 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
+	Use:   "status [skill-name]",
 	Short: "Validate symlinks and show Hub Git status",
+	Args:  cobra.MaximumNArgs(1),
 	RunE:  runStatus,
 }
 
@@ -30,6 +31,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot load config: %w\nRun 'axon init' first.", err)
 	}
 
+	// Skill-level mode: axon status <skill-name>
+	if len(args) == 1 {
+		if err := checkGitAvailable(); err != nil {
+			return err
+		}
+		fetchFirst, _ := cmd.Flags().GetBool("fetch")
+		return showSkillStatus(cfg, args[0], fetchFirst)
+	}
 	// Sort targets alphabetically by name.
 	targets := make([]config.Target, len(cfg.Targets))
 	copy(targets, cfg.Targets)
@@ -193,5 +202,87 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("git status failed: %w", err)
 	}
 	fmt.Print(string(out))
+	return nil
+}
+
+// showSkillStatus prints focused status for a single skill: path, link state,
+// recent commit history, and (with --fetch) a remote comparison.
+func showSkillStatus(cfg *config.Config, skillName string, fetchFirst bool) error {
+	// Resolve the skill path relative to the repo root.
+	skillPath, err := resolveSkillPath(cfg.RepoPath, skillName)
+	if err != nil {
+		return err
+	}
+	absSkillPath := filepath.Join(cfg.RepoPath, skillPath)
+
+	fmt.Printf("\n=== Skill: %s ===\n", skillName)
+	fmt.Printf("  Path:    %s\n", absSkillPath)
+
+	linked := false
+	for _, t := range cfg.Targets {
+		// A skill is "linked" if its path is exactly a target source,
+		// or if its path is within a target source directory (e.g. source is "skills"),
+		// or if a target source is within this skill directory.
+		if t.Source == skillPath ||
+			strings.HasPrefix(skillPath, t.Source+"/") ||
+			strings.HasPrefix(t.Source, skillPath+"/") {
+			linked = true
+			break
+		}
+	}
+	if linked {
+		fmt.Printf("  Linked:  ✓\n")
+	} else {
+		fmt.Printf("  Linked:  ✗  (not found in axon.yaml targets)\n")
+	}
+
+	// Optionally fetch remote before comparing.
+	if fetchFirst && gitHasRemote(cfg.RepoPath) {
+		printInfo("", "Fetching remote updates (origin)...")
+		fetchOut, fetchErr := exec.Command("git", "-C", cfg.RepoPath, "fetch", "--prune", "origin").CombinedOutput()
+		if fetchErr != nil {
+			trimmed := strings.TrimSpace(string(fetchOut))
+			if trimmed == "" {
+				return fmt.Errorf("git fetch failed: %w", fetchErr)
+			}
+			return fmt.Errorf("git fetch failed:\n%s", trimmed)
+		}
+		printOK("", "Fetch complete.")
+	}
+
+	// Recent commit history scoped to this skill path.
+	entries, err := gitLogEntries(cfg.RepoPath, skillPath, 0, 10)
+	if err != nil {
+		return fmt.Errorf("cannot read commit history: %w", err)
+	}
+
+	fmt.Println("\n● Recent commits:")
+	if len(entries) == 0 {
+		fmt.Println("  (no commits found for this skill path)")
+	} else {
+		for i, e := range entries {
+			fmt.Printf("  #%-2d  %s  %s   %s\n", i+1, e.sha, e.date, e.subject)
+		}
+	}
+
+	// Remote comparison (requires --fetch).
+	if fetchFirst && gitHasRemote(cfg.RepoPath) {
+		originHead, originErr := exec.Command("git", "-C", cfg.RepoPath,
+			"rev-parse", "--abbrev-ref", "origin/HEAD").Output()
+		if originErr == nil {
+			compareRef := strings.TrimSpace(string(originHead))
+			// Count commits on each side that touch this skill path.
+			// git rev-list does not support --left-right with path filters directly;
+			// so we count separately.
+			localCount, _ := gitOutput(cfg.RepoPath, "rev-list", "--count", compareRef+"..HEAD", "--", skillPath)
+			remoteCount, _ := gitOutput(cfg.RepoPath, "rev-list", "--count", "HEAD.."+compareRef, "--", skillPath)
+			ahead := strings.TrimSpace(localCount)
+			behind := strings.TrimSpace(remoteCount)
+			if ahead != "" && behind != "" {
+				fmt.Printf("\n  Remote: %s  (skill ahead %s / behind %s)\n", compareRef, ahead, behind)
+			}
+		}
+	}
+
 	return nil
 }

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -274,12 +274,14 @@ func showSkillStatus(cfg *config.Config, skillName string, fetchFirst bool) erro
 			// Count commits on each side that touch this skill path.
 			// git rev-list does not support --left-right with path filters directly;
 			// so we count separately.
-			localCount, _ := gitOutput(cfg.RepoPath, "rev-list", "--count", compareRef+"..HEAD", "--", skillPath)
-			remoteCount, _ := gitOutput(cfg.RepoPath, "rev-list", "--count", "HEAD.."+compareRef, "--", skillPath)
-			ahead := strings.TrimSpace(localCount)
-			behind := strings.TrimSpace(remoteCount)
-			if ahead != "" && behind != "" {
-				fmt.Printf("\n  Remote: %s  (skill ahead %s / behind %s)\n", compareRef, ahead, behind)
+			localCount, localErr := gitOutput(cfg.RepoPath, "rev-list", "--count", compareRef+"..HEAD", "--", skillPath)
+			remoteCount, remoteErr := gitOutput(cfg.RepoPath, "rev-list", "--count", "HEAD.."+compareRef, "--", skillPath)
+			if localErr == nil && remoteErr == nil {
+				ahead := strings.TrimSpace(localCount)
+				behind := strings.TrimSpace(remoteCount)
+				if ahead != "" && behind != "" {
+					fmt.Printf("\n  Remote: %s  (skill ahead %s / behind %s)\n", compareRef, ahead, behind)
+				}
 			}
 		}
 	}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -244,25 +244,8 @@ func gitOutput(repoPath string, args ...string) (string, error) {
 	return buf.String(), err
 }
 
-func gitOutputNoRepo(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	err := cmd.Run()
-	return buf.String(), err
-}
-
-func gitConfigValueLocal(repoPath, key string) (string, error) {
-	out, err := gitOutput(repoPath, "config", "--local", "--get", key)
-	if err != nil {
-		return "", nil
-	}
-	return strings.TrimSpace(out), nil
-}
-
-func gitConfigValueGlobal(key string) (string, error) {
-	out, err := gitOutputNoRepo("config", "--global", "--get", key)
+func gitConfigValue(repoPath, key string) (string, error) {
+	out, err := gitOutput(repoPath, "config", "--get", key)
 	if err != nil {
 		return "", nil
 	}
@@ -270,27 +253,15 @@ func gitConfigValueGlobal(key string) (string, error) {
 }
 
 func gitIdentityConfigured(repoPath string) (bool, error) {
-	localName, err := gitConfigValueLocal(repoPath, "user.name")
+	name, err := gitConfigValue(repoPath, "user.name")
 	if err != nil {
 		return false, err
 	}
-	localEmail, err := gitConfigValueLocal(repoPath, "user.email")
+	email, err := gitConfigValue(repoPath, "user.email")
 	if err != nil {
 		return false, err
 	}
-	if localName != "" && localEmail != "" {
-		return true, nil
-	}
-
-	globalName, err := gitConfigValueGlobal("user.name")
-	if err != nil {
-		return false, err
-	}
-	globalEmail, err := gitConfigValueGlobal("user.email")
-	if err != nil {
-		return false, err
-	}
-	if globalName != "" && globalEmail != "" {
+	if name != "" && email != "" {
 		return true, nil
 	}
 

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -202,70 +201,6 @@ func writeGitExcludes(cfg *config.Config) error {
 	body := strings.Join(cfg.Excludes, "\n") + "\n"
 
 	return os.WriteFile(excludeFile, []byte(header+body), 0o644)
-}
-
-// gitIsDirty reports whether the repo has uncommitted changes.
-func gitIsDirty(repoPath string) (bool, error) {
-	out, err := gitOutput(repoPath, "status", "--porcelain")
-	if err != nil {
-		return false, fmt.Errorf("git status: %w", err)
-	}
-	return strings.TrimSpace(out) != "", nil
-}
-
-// gitHasRemote reports whether the repo has any remote configured.
-func gitHasRemote(repoPath string) bool {
-	out, err := gitOutput(repoPath, "remote")
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(out) != ""
-}
-
-// gitRemoteIsEmpty reports whether the remote has no refs at all (i.e. it is a
-// brand-new empty repository that has never received a push).
-func gitRemoteIsEmpty(repoPath string) bool {
-	out, err := gitOutput(repoPath, "ls-remote", "--heads", "origin")
-	if err != nil {
-		// ls-remote failure (e.g. auth error) — treat as non-empty to be safe.
-		return false
-	}
-	return strings.TrimSpace(out) == ""
-}
-
-// gitOutput runs a git sub-command and returns its combined stdout output.
-func gitOutput(repoPath string, args ...string) (string, error) {
-	fullArgs := append([]string{"-C", repoPath}, args...)
-	cmd := exec.Command("git", fullArgs...)
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	err := cmd.Run()
-	return buf.String(), err
-}
-
-func gitConfigValue(repoPath, key string) (string, error) {
-	out, err := gitOutput(repoPath, "config", "--get", key)
-	if err != nil {
-		return "", nil
-	}
-	return strings.TrimSpace(out), nil
-}
-
-func gitIdentityConfigured(repoPath string) (bool, error) {
-	name, err := gitConfigValue(repoPath, "user.name")
-	if err != nil {
-		return false, err
-	}
-	email, err := gitConfigValue(repoPath, "user.email")
-	if err != nil {
-		return false, err
-	}
-	if name != "" && email != "" {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 // stripNestedGitDirs walks the Hub working tree and removes any .git directory

--- a/src/cmd/sync_test.go
+++ b/src/cmd/sync_test.go
@@ -135,3 +135,42 @@ func TestGitHasRemote(t *testing.T) {
 		t.Error("fresh local repo should have no remote")
 	}
 }
+
+func TestGitIdentityConfigured_LocalIdentity(t *testing.T) {
+	cfg, _ := initTestRepo(t)
+
+	ok, err := gitIdentityConfigured(cfg.RepoPath)
+	if err != nil {
+		t.Fatalf("gitIdentityConfigured returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected identity to be configured from local repo config")
+	}
+}
+
+func TestGitIdentityConfigured_MixedLocalAndGlobalIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := gitRun("-C", repo, "init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := gitRun("-C", repo, "config", "--global", "user.email", "global@example.com"); err != nil {
+		t.Fatalf("git config --global user.email: %v", err)
+	}
+	if err := gitRun("-C", repo, "config", "--local", "user.name", "Local Name"); err != nil {
+		t.Fatalf("git config --local user.name: %v", err)
+	}
+
+	ok, err := gitIdentityConfigured(repo)
+	if err != nil {
+		t.Fatalf("gitIdentityConfigured returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected identity to be configured when name/email come from different scopes")
+	}
+}


### PR DESCRIPTION
Major changes:
- Add rollback command with Git-based helpers for skill restoration
- Add status command enhancements to surface repository state details
- Add rollback test coverage for expected rollback behaviors

Minor improvements:
- Update CLI wiring in root command to register new functionality
- Update README and docs with rollback design and usage guidance

Closes #11