### PR TITLE
fix(vendor-sync): continue on per-entry errors and improve summary UX

### DIFF
--- a/src/cmd/vendor_sync.go
+++ b/src/cmd/vendor_sync.go
@@ -50,16 +50,22 @@ func runVendorSync(_ *cobra.Command, _ []string) error {
 
 	printSection("Vendor Sync")
 
+	type failedEntry struct {
+		name string
+		msg  string
+	}
+
 	var mirrored, skipped, failed int
 	var syncedNames, skippedNames []string
+	var failedEntries []failedEntry
 
 	for _, v := range cfg.Vendors {
 		ok, err := syncVendorEntry(cfg.RepoPath, v)
 		if err != nil {
-			printErr(v.Name, err.Error())
+			printErr(v.Name, "failed")
 			failed++
-			// Stop on first hard failure (MVP behaviour per plan).
-			break
+			failedEntries = append(failedEntries, failedEntry{name: v.Name, msg: err.Error()})
+			continue
 		}
 		if ok {
 			mirrored++
@@ -70,13 +76,12 @@ func runVendorSync(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Print grouped summary — always shown regardless of errors.
 	if failed > 0 {
-		return fmt.Errorf("vendor sync failed (%d mirrored, %d skipped, %d error)", mirrored, skipped, failed)
+		printErr("", fmt.Sprintf("%d error(s), %d mirrored, %d skipped", failed, mirrored, skipped))
+	} else {
+		printOK("", fmt.Sprintf("%d mirrored, %d skipped", mirrored, skipped))
 	}
-
-	printOK("", fmt.Sprintf("%d mirrored, %d skipped, %d error", mirrored, skipped, failed))
-
-	// Print grouped summary for quick overview
 	if len(syncedNames) > 0 {
 		printBullet("Synced:")
 		for _, name := range syncedNames {
@@ -89,7 +94,16 @@ func runVendorSync(_ *cobra.Command, _ []string) error {
 			printSkip(name, "")
 		}
 	}
+	if len(failedEntries) > 0 {
+		printBullet("Errors:")
+		for _, e := range failedEntries {
+			printErr(e.name, e.msg)
+		}
+	}
 
+	if failed > 0 {
+		return fmt.Errorf("vendor sync failed (%d mirrored, %d skipped, %d error)", mirrored, skipped, failed)
+	}
 	return nil
 }
 

--- a/src/cmd/vendor_sync_test.go
+++ b/src/cmd/vendor_sync_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kamusis/axon-cli/internal/config"
@@ -211,6 +212,59 @@ func TestSyncVendorEntry_SameRepoTwoSubdirs(t *testing.T) {
 		if string(data) != tc.want {
 			t.Errorf("%s: got %q, want %q", tc.path, string(data), tc.want)
 		}
+	}
+}
+
+// TestSyncVendorEntry_SubdirDeletedUpstream verifies that when the vendor subdir
+// no longer exists in the upstream repo, syncVendorEntry returns an actionable error
+// that guides the user to update axon.yaml — and does NOT modify the local destination.
+func TestSyncVendorEntry_SubdirDeletedUpstream(t *testing.T) {
+	resetVendorCache(t)
+
+	// Build a repo that contains "skills/present" but NOT "skills/deleted".
+	srcRepo := makeLocalVendorRepo(t, "skills/present", "SKILL.md", "# Present\n")
+
+	hubRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(hubRoot, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate a local copy to verify it is untouched after the failed sync.
+	localDest := filepath.Join(hubRoot, "skills", "deleted")
+	if err := os.Mkdir(localDest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localDest, "SKILL.md"), []byte("# Deleted\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := vendor.RsyncAvailable
+	vendor.RsyncAvailable = func() bool { return false }
+	defer func() { vendor.RsyncAvailable = orig }()
+
+	v := config.Vendor{
+		Name:   "deleted-skill",
+		Repo:   srcRepo,
+		Subdir: "skills/deleted",
+		Dest:   "skills/deleted",
+		Ref:    "master",
+	}
+
+	_, err := syncVendorEntry(hubRoot, v)
+	if err == nil {
+		t.Fatal("expected error when subdir is missing upstream")
+	}
+	if !strings.Contains(err.Error(), "axon.yaml") {
+		t.Errorf("error should mention axon.yaml to guide the user, got: %v", err)
+	}
+
+	// Local destination must be completely untouched.
+	data, readErr := os.ReadFile(filepath.Join(localDest, "SKILL.md"))
+	if readErr != nil {
+		t.Fatalf("local destination was unexpectedly removed: %v", readErr)
+	}
+	if string(data) != "# Deleted\n" {
+		t.Errorf("local destination content was modified, got: %q", string(data))
 	}
 }
 

--- a/src/internal/vendor/cache.go
+++ b/src/internal/vendor/cache.go
@@ -165,6 +165,9 @@ func SourcePath(cachePath, subdir string) (string, error) {
 	src := filepath.Join(cachePath, filepath.FromSlash(subdir))
 	info, err := os.Stat(src)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("subdir %q no longer exists in the upstream repo — it may have been deleted; remove or update this vendor entry in axon.yaml", subdir)
+		}
 		return "", fmt.Errorf("subdir %q not found in cache after checkout: %w", subdir, err)
 	}
 	if !info.IsDir() {


### PR DESCRIPTION
Closes #20

## Major changes
- Replace `break` with `continue` in sync loop so remaining entries are processed after a single entry fails
- Collect per-entry errors into a slice; defer detailed messages to the grouped summary section printed at the end
- Always print the full grouped summary (Synced/Skipped/Errors) regardless of whether any entry failed
- Distinguish upstream-deleted subdir with an actionable error message pointing users to update `axon.yaml`

## Minor improvements
- Add `TestSyncVendorEntry_SubdirDeletedUpstream` covering actionable error message and local-dir preservation guarantees