### PR TITLE
fix: correctly handle file_type targets in axon list and axon inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ Categories are derived from the unique `source:` paths in your `axon.yaml`. For 
 
 - `+` for directories (e.g., typical skill folders)
 - `·` for files (e.g., flat markdown workflows or rules)
+- `-` when a category is empty
+
+`type: file` targets (single-file syncs such as a shared `global_rules.md`) are collected and displayed as a deduplicated **Files** section at the end, regardless of how many targets point to the same source.
 
 Example output:
 
@@ -397,6 +400,9 @@ Example output:
 
 ● Commands
   -  (empty)
+
+● Files
+  ·  global_rules.md
 ```
 
 ### `axon search` — Keyword + Semantic

--- a/src/cmd/inspect.go
+++ b/src/cmd/inspect.go
@@ -175,7 +175,7 @@ func runInspect(_ *cobra.Command, args []string) error {
 		if i > 0 {
 			fmt.Println(strings.Repeat("─", 50))
 		}
-		printInspect(p)
+		printInspect(p, cfg.RepoPath)
 	}
 	return nil
 }
@@ -272,7 +272,7 @@ func uniqueSourceRoots(cfg *config.Config) []string {
 }
 
 // printInspect displays the formatted inspection output for one path.
-func printInspect(itemPath string) {
+func printInspect(itemPath, repoPath string) {
 	info, err := os.Stat(itemPath)
 	if err != nil {
 		printErr("", fmt.Sprintf("Error accessing path: %v", err))
@@ -300,6 +300,11 @@ func printInspect(itemPath string) {
 	category := filepath.Base(filepath.Dir(itemPath))
 	if category == "." || category == "/" || category == "" {
 		category = "Item"
+	}
+	// File targets sitting directly in the repo root have an unhelpful parent
+	// dir name ("repo"). Use "file" so the label renders as "File".
+	if !isDir && repoPath != "" && filepath.Dir(itemPath) == repoPath {
+		category = "file"
 	}
 
 	icon := inspectIconFile // Default: Small Diamond (Custom File)

--- a/src/cmd/inspect_test.go
+++ b/src/cmd/inspect_test.go
@@ -189,4 +189,21 @@ func TestResolveInspectPaths(t *testing.T) {
 			t.Error("expected error for nonexistent item")
 		}
 	})
+
+	t.Run("file-type target by filename", func(t *testing.T) {
+		os.WriteFile(filepath.Join(repo, "global_rules.md"), []byte("# Rules"), 0o644)
+		cfgWithFile := &config.Config{
+			RepoPath: repo,
+			Targets: []config.Target{
+				{Name: "codex-rules", Source: "global_rules.md", Destination: "/tmp/x", Type: "file"},
+			},
+		}
+		paths, err := resolveInspectPaths(cfgWithFile, "global_rules.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(paths) != 1 || filepath.Base(paths[0]) != "global_rules.md" {
+			t.Errorf("unexpected paths: %v", paths)
+		}
+	})
 }

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -52,6 +52,9 @@ func listItems(cfg *config.Config) []categoryItems {
 	var result []categoryItems
 
 	for _, t := range cfg.Targets {
+		if t.IsFile() {
+			continue // file-type targets are single files, not browsable categories
+		}
 		src := strings.TrimSpace(t.Source)
 		if src == "" || seen[src] {
 			continue

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -46,14 +46,23 @@ type categoryItems struct {
 }
 
 // listItems derives unique categories from cfg.Targets and scans each
-// source directory for immediate children.
+// source directory for immediate children. File-type targets are collected
+// separately and returned as a single "files" category at the end.
 func listItems(cfg *config.Config) []categoryItems {
 	seen := make(map[string]bool)
 	var result []categoryItems
+	seenFiles := make(map[string]bool)
+	var fileItems []itemInfo
 
 	for _, t := range cfg.Targets {
 		if t.IsFile() {
-			continue // file-type targets are single files, not browsable categories
+			src := strings.TrimSpace(t.Source)
+			if src == "" || seenFiles[src] {
+				continue
+			}
+			seenFiles[src] = true
+			fileItems = append(fileItems, itemInfo{Name: filepath.Base(src), IsDir: false})
+			continue
 		}
 		src := strings.TrimSpace(t.Source)
 		if src == "" || seen[src] {
@@ -80,6 +89,10 @@ func listItems(cfg *config.Config) []categoryItems {
 		}
 		// Always include the category, even if empty or source dir missing.
 		result = append(result, categoryItems{Label: label, Items: items})
+	}
+
+	if len(fileItems) > 0 {
+		result = append(result, categoryItems{Label: "files", Items: fileItems})
 	}
 	return result
 }

--- a/src/cmd/list_test.go
+++ b/src/cmd/list_test.go
@@ -139,6 +139,30 @@ func TestListItems_DeduplicatesCategories(t *testing.T) {
 	}
 }
 
+// TestListItems_SkipsFileTypeTargets — file-type targets must not appear as categories.
+func TestListItems_SkipsFileTypeTargets(t *testing.T) {
+	repo := t.TempDir()
+	makeDir(t, repo, "skills/foo")
+	makeFile(t, repo, "global_rules.md")
+
+	cfg := &config.Config{
+		RepoPath: repo,
+		Targets: []config.Target{
+			{Name: "claude-skills", Source: "skills", Destination: "/tmp/a", Type: "directory"},
+			{Name: "codex-rules", Source: "global_rules.md", Destination: "/tmp/b", Type: "file"},
+		},
+	}
+
+	cats := listItems(cfg)
+
+	if len(cats) != 1 {
+		t.Fatalf("expected 1 category (file-type target must be skipped), got %d", len(cats))
+	}
+	if cats[0].Label != "skills" {
+		t.Errorf("expected label 'skills', got %q", cats[0].Label)
+	}
+}
+
 // TestListItems_SkipsHidden — hidden entries (dot-prefixed) must not appear.
 func TestListItems_SkipsHidden(t *testing.T) {
 	repo := t.TempDir()

--- a/src/cmd/list_test.go
+++ b/src/cmd/list_test.go
@@ -139,8 +139,9 @@ func TestListItems_DeduplicatesCategories(t *testing.T) {
 	}
 }
 
-// TestListItems_SkipsFileTypeTargets — file-type targets must not appear as categories.
-func TestListItems_SkipsFileTypeTargets(t *testing.T) {
+// TestListItems_FileTypeTargetsGrouped — multiple file-type targets sharing same source
+// appear as a single "files" category at the end, deduplicated.
+func TestListItems_FileTypeTargetsGrouped(t *testing.T) {
 	repo := t.TempDir()
 	makeDir(t, repo, "skills/foo")
 	makeFile(t, repo, "global_rules.md")
@@ -150,16 +151,28 @@ func TestListItems_SkipsFileTypeTargets(t *testing.T) {
 		Targets: []config.Target{
 			{Name: "claude-skills", Source: "skills", Destination: "/tmp/a", Type: "directory"},
 			{Name: "codex-rules", Source: "global_rules.md", Destination: "/tmp/b", Type: "file"},
+			{Name: "gemini-rules", Source: "global_rules.md", Destination: "/tmp/c", Type: "file"},
 		},
 	}
 
 	cats := listItems(cfg)
 
-	if len(cats) != 1 {
-		t.Fatalf("expected 1 category (file-type target must be skipped), got %d", len(cats))
+	// Expect 2 categories: "skills" + "files"
+	if len(cats) != 2 {
+		t.Fatalf("expected 2 categories (skills + files), got %d", len(cats))
 	}
 	if cats[0].Label != "skills" {
-		t.Errorf("expected label 'skills', got %q", cats[0].Label)
+		t.Errorf("expected first label 'skills', got %q", cats[0].Label)
+	}
+	if cats[1].Label != "files" {
+		t.Errorf("expected second label 'files', got %q", cats[1].Label)
+	}
+	// Deduplicated: only one entry for global_rules.md
+	if len(cats[1].Items) != 1 {
+		t.Errorf("expected 1 file item (deduplicated), got %d", len(cats[1].Items))
+	}
+	if cats[1].Items[0].Name != "global_rules.md" {
+		t.Errorf("expected file name 'global_rules.md', got %q", cats[1].Items[0].Name)
 	}
 }
 


### PR DESCRIPTION
Fixes #29

## Summary

- `axon list`: file-type targets (e.g. `global_rules.md`) no longer appear as spurious per-target sections. They are collected into a single deduplicated **Files** section appended after directory categories.
- `axon inspect global_rules.md`: label now correctly shows `⬦ File: global_rules` instead of the misleading `⬦ Repo: global_rules` (caused by deriving the category from the repo root directory name).
- README updated to document the new `Files` section in `axon list`.

## Test plan

- [ ] `axon list` shows `● Files / · global_rules.md` instead of a `● Global_rules.md` section
- [ ] Multiple targets sharing the same source file appear as one entry under `Files`
- [ ] `axon inspect global_rules.md` shows `⬦ File: global_rules`
- [ ] `go test ./cmd/...` passes (new tests added for both behaviors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kamusis/axon-cli/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->